### PR TITLE
General `const` correctness

### DIFF
--- a/include/itm.h
+++ b/include/itm.h
@@ -72,11 +72,10 @@ DLLEXPORT int ITM_AREA_CR_Ex(double h_tx__meter, double h_rx__meter, int tx_site
 DLLEXPORT double ComputeDeltaH(const double pfl[], const double d_start__meter, const double d_end__meter);
 DLLEXPORT double DiffractionLoss(const double d__meter, const double d_hzn__meter[2], const double h_e__meter[2], const complex<double> Z_g,
     const double a_e__meter, const double delta_h__meter, const double h__meter[2], const int mode, const double theta_los, const double d_sML__meter, const double f__mhz);
-DLLEXPORT double FFunction(double td);
+DLLEXPORT double FFunction(const double td);
 DLLEXPORT void FindHorizons(const double pfl[], const double a_e__meter, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2]);
 DLLEXPORT double FreeSpaceLoss(const double d__meter, const double f__mhz);
 DLLEXPORT double FresnelIntegral(const double v2);
-DLLEXPORT double H0Curve(const int j, const double r);
 DLLEXPORT double H0Function(const double r, double eta_s);
 DLLEXPORT double HeightFunction(const double x__km, const double K);
 DLLEXPORT void InitializeArea(const int site_criteria[2], const double gamma_e, const double delta_h__meter,
@@ -86,21 +85,21 @@ DLLEXPORT void InitializePointToPoint(const double f__mhz, const double h_sys__m
 DLLEXPORT double InverseComplementaryCumulativeDistributionFunction(const double q);
 DLLEXPORT double KnifeEdgeDiffraction(const double d__meter, const double f__mhz, const double a_e__meter, const double theta_los, const double d_hzn__meter[2]);
 DLLEXPORT void LinearLeastSquaresFit(const double pfl[], const double d_start, const double d_end, double *fit_y1, double *fit_y2);
-DLLEXPORT double LineOfSightLoss(double d__meter, const double h_e__meter[2], complex<double> Z_g, double delta_h__meter,
-    double M_d, double A_d0, double d_sML__meter, double f__mhz);
-DLLEXPORT int LongleyRice(double theta_hzn[2], double f__mhz, complex<double> Z_g, double d_hzn__meter[2], double h_e__meter[2], 
-    double gamma_e, double N_s, double delta_h__meter, const double h__meter[2], double d__meter, int mode, double *A_ref__db, 
+DLLEXPORT double LineOfSightLoss(const double d__meter, const double h_e__meter[2], const complex<double> Z_g, const double delta_h__meter,
+    const double M_d, const double A_d0, const double d_sML__meter, const double f__mhz);
+DLLEXPORT int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<double> Z_g, const double d_hzn__meter[2], const double h_e__meter[2], 
+    const double gamma_e, const double N_s, const double delta_h__meter, const double h__meter[2], const double d__meter, const int mode, double *A_ref__db, 
     long *warnings, int *propmode);
-DLLEXPORT void QuickPfl(const double pfl[], double gamma_e, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2], 
+DLLEXPORT void QuickPfl(const double pfl[], const double gamma_e, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2], 
     double h_e__meter[2], double *delta_h__meter, double *d__meter);
 DLLEXPORT double SigmaHFunction(const double delta_h__meter);
 DLLEXPORT double SmoothEarthDiffraction(const double d__meter, const double f__mhz, const double a_e__meter, const double theta_los, 
     const double d_hzn__meter[2], const double h_e__meter[2], const complex<double> Z_g);
 DLLEXPORT double TerrainRoughness(const double d__meter, const double delta_h__meter);
-DLLEXPORT double TroposcatterLoss(double d__meter, const double theta_hzn[2], const double d_hzn__meter[2], const double h_e__meter[2], 
-    double a_e__meter, double N_s, double f__mhz, double theta_los, double *h0);
-DLLEXPORT int ValidateInputs(double h_tx__meter, double h_rx__meter, int climate, double time,
-    double location, double situation, double N_0, double f__mhz, int pol,
-    double epsilon, double sigma, int mdvar, long *warnings);
-DLLEXPORT double Variability(double time, double location, double situation, const double h_e__meter[2], double delta_h__meter,
-    double f__mhz, double d__meter, double A_ref__db, int climate, int mdvar, long *warnings);
+DLLEXPORT double TroposcatterLoss(const double d__meter, const double theta_hzn[2], const double d_hzn__meter[2], const double h_e__meter[2], 
+    const double a_e__meter, const double N_s, const double f__mhz, const double theta_los, double *h0);
+DLLEXPORT int ValidateInputs(const double h_tx__meter, const double h_rx__meter, const int climate, const double time,
+    const double location, const double situation, const double N_0, const double f__mhz, const int pol,
+    const double epsilon, const double sigma, const int mdvar, long *warnings);
+DLLEXPORT double Variability(const double time, const double location, const double situation, const double h_e__meter[2], const double delta_h__meter,
+    const double f__mhz, const double d__meter, const double A_ref__db, int climate, int mdvar, long *warnings);

--- a/include/itm.h
+++ b/include/itm.h
@@ -42,29 +42,29 @@ struct IntermediateValues
 // Main ITM Functions
 
 DLLEXPORT int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
+    const int pol, const double epsilon, const double sigma, const int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings);
 DLLEXPORT int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
+    const int pol, const double epsilon, const double sigma, const int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings, IntermediateValues *interValues);
 DLLEXPORT int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
+    const int pol, const double epsilon, const double sigma, const int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings);
 DLLEXPORT int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
+    const int pol, const double epsilon, const double sigma, const int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues);
 DLLEXPORT int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, const int climate, const double N_0, double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings);
+    const int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings);
 DLLEXPORT int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings, IntermediateValues *interValues);
+    const int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings, IntermediateValues *interValues);
 DLLEXPORT int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, const double confidence, const double reliability, double *A__db, long *warnings);
+    const int mdvar, const double confidence, const double reliability, double *A__db, long *warnings);
 DLLEXPORT int ITM_AREA_CR_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, const double confidence, const double reliability, double *A__db, long *warnings, IntermediateValues *interValues);
+    const int mdvar, const double confidence, const double reliability, double *A__db, long *warnings, IntermediateValues *interValues);
 
 /////////////////////////////
 // ITM Helper Functions
@@ -102,4 +102,4 @@ DLLEXPORT int ValidateInputs(const double h_tx__meter, const double h_rx__meter,
     const double location, const double situation, const double N_0, const double f__mhz, const int pol,
     const double epsilon, const double sigma, const int mdvar, long *warnings);
 DLLEXPORT double Variability(const double time, const double location, const double situation, const double h_e__meter[2], const double delta_h__meter,
-    const double f__mhz, const double d__meter, const double A_ref__db, const int climate, int mdvar, long *warnings);
+    const double f__mhz, const double d__meter, const double A_ref__db, const int climate, const int mdvar, long *warnings);

--- a/include/itm.h
+++ b/include/itm.h
@@ -42,29 +42,29 @@ struct IntermediateValues
 // Main ITM Functions
 
 DLLEXPORT int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, double time, double location, double situation,
+    const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings);
 DLLEXPORT int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, double time, double location, double situation,
+    const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings, IntermediateValues *interValues);
 DLLEXPORT int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, double confidence, double reliability,
+    const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings);
 DLLEXPORT int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, double confidence, double reliability,
+    const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues);
 DLLEXPORT int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, double time, double location, double situation, double *A__db, long *warnings);
+    int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings);
 DLLEXPORT int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, double time, double location, double situation, double *A__db, long *warnings, IntermediateValues *interValues);
+    int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings, IntermediateValues *interValues);
 DLLEXPORT int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, double confidence, double reliability, double *A__db, long *warnings);
+    int mdvar, const double confidence, const double reliability, double *A__db, long *warnings);
 DLLEXPORT int ITM_AREA_CR_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, double confidence, double reliability, double *A__db, long *warnings, IntermediateValues *interValues);
+    int mdvar, const double confidence, const double reliability, double *A__db, long *warnings, IntermediateValues *interValues);
 
 /////////////////////////////
 // ITM Helper Functions

--- a/include/itm.h
+++ b/include/itm.h
@@ -41,29 +41,29 @@ struct IntermediateValues
 /////////////////////////////
 // Main ITM Functions
 
-DLLEXPORT int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+DLLEXPORT int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
     const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings);
-DLLEXPORT int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+DLLEXPORT int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
     const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings, IntermediateValues *interValues);
-DLLEXPORT int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+DLLEXPORT int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
     const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings);
-DLLEXPORT int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+DLLEXPORT int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
     const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues);
 DLLEXPORT int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
-    const double delta_h__meter, int climate, const double N_0, double f__mhz, const int pol, const double epsilon, const double sigma,
+    const double delta_h__meter, const int climate, const double N_0, double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings);
 DLLEXPORT int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
-    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
+    const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings, IntermediateValues *interValues);
 DLLEXPORT int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
-    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
+    const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, const double confidence, const double reliability, double *A__db, long *warnings);
 DLLEXPORT int ITM_AREA_CR_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
-    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
+    const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, const double confidence, const double reliability, double *A__db, long *warnings, IntermediateValues *interValues);
 
 /////////////////////////////
@@ -102,4 +102,4 @@ DLLEXPORT int ValidateInputs(const double h_tx__meter, const double h_rx__meter,
     const double location, const double situation, const double N_0, const double f__mhz, const int pol,
     const double epsilon, const double sigma, const int mdvar, long *warnings);
 DLLEXPORT double Variability(const double time, const double location, const double situation, const double h_e__meter[2], const double delta_h__meter,
-    const double f__mhz, const double d__meter, const double A_ref__db, int climate, int mdvar, long *warnings);
+    const double f__mhz, const double d__meter, const double A_ref__db, const int climate, int mdvar, long *warnings);

--- a/include/itm.h
+++ b/include/itm.h
@@ -41,16 +41,16 @@ struct IntermediateValues
 /////////////////////////////
 // Main ITM Functions
 
-DLLEXPORT int ITM_P2P_TLS(double h_tx__meter, double h_rx__meter, double pfl[], int climate, double N_0, double f__mhz,
+DLLEXPORT int ITM_P2P_TLS(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
     int pol, double epsilon, double sigma, int mdvar, double time, double location, double situation,
     double *A__db, long *warnings);
-DLLEXPORT int ITM_P2P_TLS_Ex(double h_tx__meter, double h_rx__meter, double pfl[], int climate, double N_0, double f__mhz,
+DLLEXPORT int ITM_P2P_TLS_Ex(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
     int pol, double epsilon, double sigma, int mdvar, double time, double location, double situation,
     double *A__db, long *warnings, IntermediateValues *interValues);
-DLLEXPORT int ITM_P2P_CR(double h_tx__meter, double h_rx__meter, double pfl[], int climate, double N_0, double f__mhz,
+DLLEXPORT int ITM_P2P_CR(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
     int pol, double epsilon, double sigma, int mdvar, double confidence, double reliability,
     double *A__db, long *warnings);
-DLLEXPORT int ITM_P2P_CR_Ex(double h_tx__meter, double h_rx__meter, double pfl[], int climate, double N_0, double f__mhz,
+DLLEXPORT int ITM_P2P_CR_Ex(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
     int pol, double epsilon, double sigma, int mdvar, double confidence, double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues);
 DLLEXPORT int ITM_AREA_TLS(double h_tx__meter, double h_rx__meter, int tx_site_criteria, int rx_site_criteria, double d__km,
@@ -69,37 +69,37 @@ DLLEXPORT int ITM_AREA_CR_Ex(double h_tx__meter, double h_rx__meter, int tx_site
 /////////////////////////////
 // ITM Helper Functions
 
-DLLEXPORT double ComputeDeltaH(double pfl[], double d_start__meter, double d_end__meter);
+DLLEXPORT double ComputeDeltaH(const double pfl[], double d_start__meter, double d_end__meter);
 DLLEXPORT double DiffractionLoss(double d__meter, double d_hzn__meter[2], double h_e__meter[2], complex<double> Z_g,
-    double a_e__meter, double delta_h__meter, double h__meter[2], int mode, double theta_los, double d_sML__meter, double f__mhz);
+    double a_e__meter, double delta_h__meter, const double h__meter[2], int mode, double theta_los, double d_sML__meter, double f__mhz);
 DLLEXPORT double FFunction(double td);
-DLLEXPORT void FindHorizons(double pfl[], double a_e__meter, double h__meter[2], double theta_hzn[2], double d_hzn__meter[2]);
+DLLEXPORT void FindHorizons(const double pfl[], double a_e__meter, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2]);
 DLLEXPORT double FreeSpaceLoss(double d__meter, double f__mhz);
 DLLEXPORT double FresnelIntegral(double v2);
 DLLEXPORT double H0Function(double r, double eta_s);
 DLLEXPORT double HeightFunction(double x__meter, double K);
-DLLEXPORT void InitializeArea(int site_criteria[2], double gamma_e, double delta_h__meter,
-    double h__meter[2], double h_e__meter[2], double d_hzn__meter[2], double theta_hzn[2]);
+DLLEXPORT void InitializeArea(const int site_criteria[2], double gamma_e, double delta_h__meter,
+    const double h__meter[2], double h_e__meter[2], double d_hzn__meter[2], double theta_hzn[2]);
 DLLEXPORT void InitializePointToPoint(double f__mhz, double h_sys__meter, double N_0, int polarization, double epsilon, 
     double sigma, complex<double> *Z_g, double *gamma_e, double *N_s);
 DLLEXPORT double InverseComplementaryCumulativeDistributionFunction(double q);
-DLLEXPORT double KnifeEdgeDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, double d_hzn__meter[2]);
-DLLEXPORT void LinearLeastSquaresFit(double pfl[], double d_start, double d_end, double *fit_y1, double *fit_y2);
-DLLEXPORT double LineOfSightLoss(double d__meter, double h_e__meter[2], complex<double> Z_g, double delta_h__meter,
+DLLEXPORT double KnifeEdgeDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, const double d_hzn__meter[2]);
+DLLEXPORT void LinearLeastSquaresFit(const double pfl[], double d_start, double d_end, double *fit_y1, double *fit_y2);
+DLLEXPORT double LineOfSightLoss(double d__meter, const double h_e__meter[2], complex<double> Z_g, double delta_h__meter,
     double M_d, double A_d0, double d_sML__meter, double f__mhz);
 DLLEXPORT int LongleyRice(double theta_hzn[2], double f__mhz, complex<double> Z_g, double d_hzn__meter[2], double h_e__meter[2], 
-    double gamma_e, double N_s, double delta_h__meter, double h__meter[2], double d__meter, int mode, double *A_ref__db, 
+    double gamma_e, double N_s, double delta_h__meter, const double h__meter[2], double d__meter, int mode, double *A_ref__db, 
     long *warnings, int *propmode);
-DLLEXPORT void QuickPfl(double pfl[], double gamma_e, double h__meter[2], double theta_hzn[2], double d_hzn__meter[2], 
+DLLEXPORT void QuickPfl(const double pfl[], double gamma_e, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2], 
     double h_e__meter[2], double *delta_h__meter, double *d__meter);
 DLLEXPORT double SigmaHFunction(double delta_h__meter);
 DLLEXPORT double SmoothEarthDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, 
-    double d_hzn__meter[2], double h_e__meter[2], complex<double> Z_g);
+    const double d_hzn__meter[2], const double h_e__meter[2], complex<double> Z_g);
 DLLEXPORT double TerrainRoughness(double d__meter, double delta_h__meter);
-DLLEXPORT double TroposcatterLoss(double d__meter, double theta_hzn[2], double d_hzn__meter[2], double h_e__meter[2], 
+DLLEXPORT double TroposcatterLoss(double d__meter, const double theta_hzn[2], const double d_hzn__meter[2], const double h_e__meter[2], 
     double a_e__meter, double N_s, double f__mhz, double theta_los, double *h0);
 DLLEXPORT int ValidateInputs(double h_tx__meter, double h_rx__meter, int climate, double time,
     double location, double situation, double N_0, double f__mhz, int pol,
     double epsilon, double sigma, int mdvar, long *warnings);
-DLLEXPORT double Variability(double time, double location, double situation, double h_e__meter[2], double delta_h__meter,
+DLLEXPORT double Variability(double time, double location, double situation, const double h_e__meter[2], double delta_h__meter,
     double f__mhz, double d__meter, double A_ref__db, int climate, int mdvar, long *warnings);

--- a/include/itm.h
+++ b/include/itm.h
@@ -69,22 +69,23 @@ DLLEXPORT int ITM_AREA_CR_Ex(double h_tx__meter, double h_rx__meter, int tx_site
 /////////////////////////////
 // ITM Helper Functions
 
-DLLEXPORT double ComputeDeltaH(const double pfl[], double d_start__meter, double d_end__meter);
-DLLEXPORT double DiffractionLoss(double d__meter, double d_hzn__meter[2], double h_e__meter[2], complex<double> Z_g,
-    double a_e__meter, double delta_h__meter, const double h__meter[2], int mode, double theta_los, double d_sML__meter, double f__mhz);
+DLLEXPORT double ComputeDeltaH(const double pfl[], const double d_start__meter, const double d_end__meter);
+DLLEXPORT double DiffractionLoss(const double d__meter, const double d_hzn__meter[2], const double h_e__meter[2], const complex<double> Z_g,
+    const double a_e__meter, const double delta_h__meter, const double h__meter[2], const int mode, const double theta_los, const double d_sML__meter, const double f__mhz);
 DLLEXPORT double FFunction(double td);
-DLLEXPORT void FindHorizons(const double pfl[], double a_e__meter, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2]);
-DLLEXPORT double FreeSpaceLoss(double d__meter, double f__mhz);
-DLLEXPORT double FresnelIntegral(double v2);
-DLLEXPORT double H0Function(double r, double eta_s);
-DLLEXPORT double HeightFunction(double x__meter, double K);
-DLLEXPORT void InitializeArea(const int site_criteria[2], double gamma_e, double delta_h__meter,
+DLLEXPORT void FindHorizons(const double pfl[], const double a_e__meter, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2]);
+DLLEXPORT double FreeSpaceLoss(const double d__meter, const double f__mhz);
+DLLEXPORT double FresnelIntegral(const double v2);
+DLLEXPORT double H0Curve(const int j, const double r);
+DLLEXPORT double H0Function(const double r, double eta_s);
+DLLEXPORT double HeightFunction(const double x__meter, const double K);
+DLLEXPORT void InitializeArea(const int site_criteria[2], const double gamma_e, const double delta_h__meter,
     const double h__meter[2], double h_e__meter[2], double d_hzn__meter[2], double theta_hzn[2]);
-DLLEXPORT void InitializePointToPoint(double f__mhz, double h_sys__meter, double N_0, int polarization, double epsilon, 
-    double sigma, complex<double> *Z_g, double *gamma_e, double *N_s);
-DLLEXPORT double InverseComplementaryCumulativeDistributionFunction(double q);
-DLLEXPORT double KnifeEdgeDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, const double d_hzn__meter[2]);
-DLLEXPORT void LinearLeastSquaresFit(const double pfl[], double d_start, double d_end, double *fit_y1, double *fit_y2);
+DLLEXPORT void InitializePointToPoint(const double f__mhz, const double h_sys__meter, const double N_0, const int polarization, const double epsilon, 
+    const double sigma, complex<double> *Z_g, double *gamma_e, double *N_s);
+DLLEXPORT double InverseComplementaryCumulativeDistributionFunction(const double q);
+DLLEXPORT double KnifeEdgeDiffraction(const double d__meter, const double f__mhz, const double a_e__meter, const double theta_los, const double d_hzn__meter[2]);
+DLLEXPORT void LinearLeastSquaresFit(const double pfl[], const double d_start, const double d_end, double *fit_y1, double *fit_y2);
 DLLEXPORT double LineOfSightLoss(double d__meter, const double h_e__meter[2], complex<double> Z_g, double delta_h__meter,
     double M_d, double A_d0, double d_sML__meter, double f__mhz);
 DLLEXPORT int LongleyRice(double theta_hzn[2], double f__mhz, complex<double> Z_g, double d_hzn__meter[2], double h_e__meter[2], 
@@ -92,10 +93,10 @@ DLLEXPORT int LongleyRice(double theta_hzn[2], double f__mhz, complex<double> Z_
     long *warnings, int *propmode);
 DLLEXPORT void QuickPfl(const double pfl[], double gamma_e, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2], 
     double h_e__meter[2], double *delta_h__meter, double *d__meter);
-DLLEXPORT double SigmaHFunction(double delta_h__meter);
-DLLEXPORT double SmoothEarthDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, 
-    const double d_hzn__meter[2], const double h_e__meter[2], complex<double> Z_g);
-DLLEXPORT double TerrainRoughness(double d__meter, double delta_h__meter);
+DLLEXPORT double SigmaHFunction(const double delta_h__meter);
+DLLEXPORT double SmoothEarthDiffraction(const double d__meter, const double f__mhz, const double a_e__meter, const double theta_los, 
+    const double d_hzn__meter[2], const double h_e__meter[2], const complex<double> Z_g);
+DLLEXPORT double TerrainRoughness(const double d__meter, const double delta_h__meter);
 DLLEXPORT double TroposcatterLoss(double d__meter, const double theta_hzn[2], const double d_hzn__meter[2], const double h_e__meter[2], 
     double a_e__meter, double N_s, double f__mhz, double theta_los, double *h0);
 DLLEXPORT int ValidateInputs(double h_tx__meter, double h_rx__meter, int climate, double time,

--- a/include/itm.h
+++ b/include/itm.h
@@ -41,29 +41,29 @@ struct IntermediateValues
 /////////////////////////////
 // Main ITM Functions
 
-DLLEXPORT int ITM_P2P_TLS(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
-    int pol, double epsilon, double sigma, int mdvar, double time, double location, double situation,
+DLLEXPORT int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+    const int pol, const double epsilon, const double sigma, int mdvar, double time, double location, double situation,
     double *A__db, long *warnings);
-DLLEXPORT int ITM_P2P_TLS_Ex(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
-    int pol, double epsilon, double sigma, int mdvar, double time, double location, double situation,
+DLLEXPORT int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+    const int pol, const double epsilon, const double sigma, int mdvar, double time, double location, double situation,
     double *A__db, long *warnings, IntermediateValues *interValues);
-DLLEXPORT int ITM_P2P_CR(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
-    int pol, double epsilon, double sigma, int mdvar, double confidence, double reliability,
+DLLEXPORT int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+    const int pol, const double epsilon, const double sigma, int mdvar, double confidence, double reliability,
     double *A__db, long *warnings);
-DLLEXPORT int ITM_P2P_CR_Ex(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
-    int pol, double epsilon, double sigma, int mdvar, double confidence, double reliability,
+DLLEXPORT int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+    const int pol, const double epsilon, const double sigma, int mdvar, double confidence, double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues);
-DLLEXPORT int ITM_AREA_TLS(double h_tx__meter, double h_rx__meter, int tx_site_criteria, int rx_site_criteria, double d__km,
-    double delta_h__meter, int climate, double N_0, double f__mhz, int pol, double epsilon, double sigma,
+DLLEXPORT int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
+    const double delta_h__meter, int climate, const double N_0, double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, double time, double location, double situation, double *A__db, long *warnings);
-DLLEXPORT int ITM_AREA_TLS_Ex(double h_tx__meter, double h_rx__meter, int tx_site_criteria, int rx_site_criteria, double d__km,
-    double delta_h__meter, int climate, double N_0, double f__mhz, int pol, double epsilon, double sigma,
+DLLEXPORT int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
+    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, double time, double location, double situation, double *A__db, long *warnings, IntermediateValues *interValues);
-DLLEXPORT int ITM_AREA_CR(double h_tx__meter, double h_rx__meter, int tx_site_criteria, int rx_site_criteria, double d__km,
-    double delta_h__meter, int climate, double N_0, double f__mhz, int pol, double epsilon, double sigma,
+DLLEXPORT int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
+    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, double confidence, double reliability, double *A__db, long *warnings);
-DLLEXPORT int ITM_AREA_CR_Ex(double h_tx__meter, double h_rx__meter, int tx_site_criteria, int rx_site_criteria, double d__km,
-    double delta_h__meter, int climate, double N_0, double f__mhz, int pol, double epsilon, double sigma,
+DLLEXPORT int ITM_AREA_CR_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
+    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, double confidence, double reliability, double *A__db, long *warnings, IntermediateValues *interValues);
 
 /////////////////////////////

--- a/src/ComputeDeltaH.cpp
+++ b/src/ComputeDeltaH.cpp
@@ -15,7 +15,7 @@
  |      Returns:  delta_h__meter - Terrain irregularity parameter, in meters
  |
  *===========================================================================*/
-double ComputeDeltaH(const double pfl[], double d_start__meter, double d_end__meter)
+double ComputeDeltaH(const double pfl[], const double d_start__meter, const double d_end__meter)
 {
     double s[247] = { 0 };                      // Temp pfl data array
 

--- a/src/ComputeDeltaH.cpp
+++ b/src/ComputeDeltaH.cpp
@@ -15,7 +15,7 @@
  |      Returns:  delta_h__meter - Terrain irregularity parameter, in meters
  |
  *===========================================================================*/
-double ComputeDeltaH(double pfl[], double d_start__meter, double d_end__meter)
+double ComputeDeltaH(const double pfl[], double d_start__meter, double d_end__meter)
 {
     double s[247] = { 0 };                      // Temp pfl data array
 

--- a/src/ComputeDeltaH.cpp
+++ b/src/ComputeDeltaH.cpp
@@ -19,7 +19,7 @@ double ComputeDeltaH(const double pfl[], const double d_start__meter, const doub
 {
     double s[247] = { 0 };                      // Temp pfl data array
 
-    int np = (int)pfl[0];
+    const int np = (int)pfl[0];
     double x_start = d_start__meter / pfl[1];   // index to start considering terrain points
     double x_end = d_end__meter / pfl[1];       // index to stop considering terrain points
 
@@ -30,7 +30,7 @@ double ComputeDeltaH(const double pfl[], const double d_start__meter, const doub
     int p10 = (int)(0.1 * (x_end - x_start + 8.0));
     p10 = MIN(MAX(4, p10), 25);                 // 10% index
 
-    int n = 10 * p10 - 5;
+    const int n = 10 * p10 - 5;
     int p90 = n - p10;                         // 90% index
 
     double np_s = n - 1;
@@ -70,15 +70,15 @@ double ComputeDeltaH(const double pfl[], const double d_start__meter, const doub
     }
 
     std::nth_element(diffs.begin(), diffs.begin() + p10 - 1, diffs.end(), std::greater<double>());
-    double q10 = diffs[p10 - 1];
+    const double q10 = diffs[p10 - 1];
 
     std::nth_element(diffs.begin(), diffs.begin() + p90, diffs.end(), std::greater<double>());
-    double q90 = diffs[p90];
+    const double q90 = diffs[p90];
 
-    double delta_h_d__meter = q10 - q90;
+    const double delta_h_d__meter = q10 - q90;
 
     // [ERL 79-ITS 67, Eqn 3], inverted
-    double delta_h__meter = delta_h_d__meter / (1.0 - 0.8 * exp(-(d_end__meter - d_start__meter) / 50e3));
+    const double delta_h__meter = delta_h_d__meter / (1.0 - 0.8 * exp(-(d_end__meter - d_start__meter) / 50e3));
 
     return delta_h__meter;
 }

--- a/src/DiffractionLoss.cpp
+++ b/src/DiffractionLoss.cpp
@@ -25,45 +25,45 @@
 double DiffractionLoss(const double d__meter, const double d_hzn__meter[2], const double h_e__meter[2], const complex<double> Z_g, const double a_e__meter, 
     const double delta_h__meter, const double h__meter[2], const int mode, const double theta_los, const double d_sML__meter, const double f__mhz)
 {
-    double A_k__db = KnifeEdgeDiffraction(d__meter, f__mhz, a_e__meter, theta_los, d_hzn__meter);
+    const double A_k__db = KnifeEdgeDiffraction(d__meter, f__mhz, a_e__meter, theta_los, d_hzn__meter);
 
-    double A_se__db = SmoothEarthDiffraction(d__meter, f__mhz, a_e__meter, theta_los, d_hzn__meter, h_e__meter, Z_g);
+    const double A_se__db = SmoothEarthDiffraction(d__meter, f__mhz, a_e__meter, theta_los, d_hzn__meter, h_e__meter, Z_g);
 
     //////////////////
     // Terrain clutter
 
     // Terrain roughness term, using d_sML__meter, per [ERL 79-ITS 67, page 3-13]
-    double delta_h_dsML__meter = TerrainRoughness(d_sML__meter, delta_h__meter);
+    const double delta_h_dsML__meter = TerrainRoughness(d_sML__meter, delta_h__meter);
 
-    double sigma_h_d__meter = SigmaHFunction(delta_h_dsML__meter);
+    const double sigma_h_d__meter = SigmaHFunction(delta_h_dsML__meter);
 
     // Clutter factor
     // [ERL 79-ITS 67, Eqn 3.38c]
-    double A_fo__db = MIN(15.0, 5 * log10(1.0 + 1e-5 * h__meter[0] * h__meter[1] * f__mhz * sigma_h_d__meter));
+    const double A_fo__db = MIN(15.0, 5 * log10(1.0 + 1e-5 * h__meter[0] * h__meter[1] * f__mhz * sigma_h_d__meter));
 
     //////////////////////////////
     // Combined diffraction losses
 
     // compute the weighting factor in the following calculations
 
-    double delta_h_d__meter = TerrainRoughness(d__meter, delta_h__meter);
+    const double delta_h_d__meter = TerrainRoughness(d__meter, delta_h__meter);
 
     double q = h__meter[0] * h__meter[1];
-    double qk = h_e__meter[0] * h_e__meter[1] - q;
+    const double qk = h_e__meter[0] * h_e__meter[1] - q;
 
     // For low antennas with known path parameters, C ~= 10 [ERL 79-ITS 67, page 3-8]
     if (mode == MODE__P2P)
         q += 10.0;
 
-    double term1 = sqrt(1.0 + qk / q);                              // square root term in [ERL 79-ITS 67, Eqn 3.23]
+    const double term1 = sqrt(1.0 + qk / q);                              // square root term in [ERL 79-ITS 67, Eqn 3.23]
 
-    double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];         // Maximum line-of-sight distance for actual path
+    const double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];         // Maximum line-of-sight distance for actual path
     q = (term1 + (-theta_los * a_e__meter + d_ML__meter) / d__meter) * MIN(delta_h_d__meter * f__mhz / 47.7, 6283.2);
 
     // weighting factor [ERL 17-ITS 67, Eqn 3.23]
-    double w = 25.1 / (25.1 + sqrt(q));
+    const double w = 25.1 / (25.1 + sqrt(q));
 
-    double A_d__db = w * A_se__db + (1.0 - w) * A_k__db + A_fo__db;
+    const double A_d__db = w * A_se__db + (1.0 - w) * A_k__db + A_fo__db;
 
     return A_d__db;
 }

--- a/src/DiffractionLoss.cpp
+++ b/src/DiffractionLoss.cpp
@@ -22,8 +22,8 @@
  |      Returns:  A_d__db        - Diffraction loss, in dB
  |
  *===========================================================================*/
-double DiffractionLoss(double d__meter, double d_hzn__meter[2], double h_e__meter[2], complex<double> Z_g, double a_e__meter, 
-    double delta_h__meter, const double h__meter[2], int mode, double theta_los, double d_sML__meter, double f__mhz)
+double DiffractionLoss(const double d__meter, const double d_hzn__meter[2], const double h_e__meter[2], const complex<double> Z_g, const double a_e__meter, 
+    const double delta_h__meter, const double h__meter[2], const int mode, const double theta_los, const double d_sML__meter, const double f__mhz)
 {
     double A_k__db = KnifeEdgeDiffraction(d__meter, f__mhz, a_e__meter, theta_los, d_hzn__meter);
 

--- a/src/DiffractionLoss.cpp
+++ b/src/DiffractionLoss.cpp
@@ -23,7 +23,7 @@
  |
  *===========================================================================*/
 double DiffractionLoss(double d__meter, double d_hzn__meter[2], double h_e__meter[2], complex<double> Z_g, double a_e__meter, 
-    double delta_h__meter, double h__meter[2], int mode, double theta_los, double d_sML__meter, double f__mhz)
+    double delta_h__meter, const double h__meter[2], int mode, double theta_los, double d_sML__meter, double f__mhz)
 {
     double A_k__db = KnifeEdgeDiffraction(d__meter, f__mhz, a_e__meter, theta_los, d_hzn__meter);
 

--- a/src/FindHorizons.cpp
+++ b/src/FindHorizons.cpp
@@ -14,7 +14,7 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-void FindHorizons(double pfl[], double a_e__meter, double h__meter[2], double theta_hzn[2], double d_hzn__meter[2])
+void FindHorizons(const double pfl[], double a_e__meter, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2])
 {
     int np = int(pfl[0]);
     double xi = pfl[1];

--- a/src/FindHorizons.cpp
+++ b/src/FindHorizons.cpp
@@ -14,7 +14,7 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-void FindHorizons(const double pfl[], double a_e__meter, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2])
+void FindHorizons(const double pfl[], const double a_e__meter, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2])
 {
     int np = int(pfl[0]);
     double xi = pfl[1];

--- a/src/FindHorizons.cpp
+++ b/src/FindHorizons.cpp
@@ -16,14 +16,14 @@
  *===========================================================================*/
 void FindHorizons(const double pfl[], const double a_e__meter, const double h__meter[2], double theta_hzn[2], double d_hzn__meter[2])
 {
-    int np = int(pfl[0]);
-    double xi = pfl[1];
+    const int np = int(pfl[0]);
+    const double xi = pfl[1];
 
-    double d__meter = pfl[0] * pfl[1];
+    const double d__meter = pfl[0] * pfl[1];
 
     // compute radials (ignore radius of earth since it cancels out in the later math)
-    double z_tx__meter = pfl[2] + h__meter[0];
-    double z_rx__meter = pfl[np + 2] + h__meter[1];
+    const double z_tx__meter = pfl[2] + h__meter[0];
+    const double z_rx__meter = pfl[np + 2] + h__meter[1];
 
     // set the terminal horizon angles as if the terminals are line-of-sight
     // [TN101, Eq 6.15]

--- a/src/FreeSpaceLoss.cpp
+++ b/src/FreeSpaceLoss.cpp
@@ -12,7 +12,7 @@
  |      Returns:  A_fs__db       - Free space basic transmission loss, in dB
  |
  *===========================================================================*/
-double FreeSpaceLoss(double d__meter, double f__mhz)
+double FreeSpaceLoss(const double d__meter, const double f__mhz)
 {
     return 32.45 + 20.0 * log10(f__mhz) + 20.0 * log10(d__meter / 1000.0);
 }

--- a/src/FresnelIntegral.cpp
+++ b/src/FresnelIntegral.cpp
@@ -11,7 +11,7 @@
  |      Returns:  A(v, 0)        - Loss, in dB
  |
  *===========================================================================*/
-double FresnelIntegral(double v2)
+double FresnelIntegral(const double v2)
 {
     // Note: v2  is v^2, so 5.76 is actually comparing v to 2.4
 

--- a/src/H0Function.cpp
+++ b/src/H0Function.cpp
@@ -15,8 +15,8 @@
 double H0Curve(int j, double r)
 {
     // values from [Algorithm, 6.13]
-    double a[] = { 25.0, 80.0, 177.0, 395.0, 705.0 };
-    double b[] = { 24.0, 45.0, 68.0, 80.0, 105.0 };
+    const double a[] = { 25.0, 80.0, 177.0, 395.0, 705.0 };
+    const double b[] = { 24.0, 45.0, 68.0, 80.0, 105.0 };
 
     return 10 * log10(1 + a[j] * pow(1 / r, 4) + b[j] * pow(1.0 / r, 2));    // related to TN101v2, Eqn III.49, but from [Algorithm, 6.13]
 }

--- a/src/H0Function.cpp
+++ b/src/H0Function.cpp
@@ -12,7 +12,7 @@
  |      Returns: H_01(r, j)      - in dB
  |
  *===========================================================================*/
-double H0Curve(int j, double r)
+double H0Curve(const int j, const double r)
 {
     // values from [Algorithm, 6.13]
     const double a[] = { 25.0, 80.0, 177.0, 395.0, 705.0 };
@@ -35,7 +35,7 @@ double H0Curve(int j, double r)
  |      Returns:  H_0()          - in dB
  |
  *===========================================================================*/
-double H0Function(double r, double eta_s)
+double H0Function(const double r, double eta_s)
 {
     eta_s = MIN(MAX(eta_s, 1), 5);  // range 1 <= eta_s <= 5
 

--- a/src/H0Function.cpp
+++ b/src/H0Function.cpp
@@ -39,8 +39,8 @@ double H0Function(const double r, double eta_s)
 {
     eta_s = MIN(MAX(eta_s, 1), 5);  // range 1 <= eta_s <= 5
 
-    int i = int(eta_s);             // integer part of eta_s
-    double q = eta_s - i;           // decimal part of eta_s
+    const int i = int(eta_s);       // integer part of eta_s
+    const double q = eta_s - i;     // decimal part of eta_s
 
     double result = H0Curve(i - 1, r);
 

--- a/src/InitializeArea.cpp
+++ b/src/InitializeArea.cpp
@@ -20,8 +20,8 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-void InitializeArea(int site_criteria[2], double gamma_e, double delta_h__meter,
-    double h__meter[2], double h_e__meter[2], double d_hzn__meter[2],  double theta_hzn[2])
+void InitializeArea(const int site_criteria[2], double gamma_e, double delta_h__meter,
+    const double h__meter[2], double h_e__meter[2], double d_hzn__meter[2],  double theta_hzn[2])
 {
     for (int i = 0; i < 2; i++)
     {

--- a/src/InitializeArea.cpp
+++ b/src/InitializeArea.cpp
@@ -43,10 +43,10 @@ void InitializeArea(const int site_criteria[2], const double gamma_e, const doub
             h_e__meter[i] = h__meter[i] + (1.0 + B) * exp(-MIN(20.0, 2.0 * h__meter[i] / MAX(1e-3, delta_h__meter)));
         }
 
-        double d_Ls__meter = sqrt(2.0 * h_e__meter[i] / gamma_e);
+        const double d_Ls__meter = sqrt(2.0 * h_e__meter[i] / gamma_e);
 
         // [Algorithm, Eqn 3.3]
-        double H_3__meter = 5;
+        constexpr double H_3__meter = 5;
         d_hzn__meter[i] = d_Ls__meter * exp(-0.07 * sqrt(delta_h__meter / MAX(h_e__meter[i], H_3__meter)));
 
         // [Algorithm, Eqn 3.4]

--- a/src/InitializeArea.cpp
+++ b/src/InitializeArea.cpp
@@ -20,7 +20,7 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-void InitializeArea(const int site_criteria[2], double gamma_e, double delta_h__meter,
+void InitializeArea(const int site_criteria[2], const double gamma_e, const double delta_h__meter,
     const double h__meter[2], double h_e__meter[2], double d_hzn__meter[2],  double theta_hzn[2])
 {
     for (int i = 0; i < 2; i++)

--- a/src/InitializePointToPoint.cpp
+++ b/src/InitializePointToPoint.cpp
@@ -26,7 +26,7 @@ void InitializePointToPoint(const double f__mhz, const double h_sys__meter, cons
     const double epsilon, const double sigma, complex<double> *Z_g, double *gamma_e, double *N_s)
 {
     // gamma_a is the curvature of the actual earth, ~1 / 6370 km
-    double gamma_a = 157e-9;
+    constexpr double gamma_a = 157e-9;
 
     // scale the refractivity based on the elevation above mean sea level
     if (h_sys__meter == 0.0)
@@ -38,7 +38,7 @@ void InitializePointToPoint(const double f__mhz, const double h_sys__meter, cons
     *gamma_e = gamma_a * (1.0 - 0.04665 * exp(*N_s / 179.3));   // [TN101, Eq 4.4], reworked
 
     // complex relative permittivity
-    complex<double> ep_r = complex<double>(epsilon, 18000 * sigma / f__mhz);
+    const complex<double> ep_r = complex<double>(epsilon, 18000 * sigma / f__mhz);
 
     *Z_g = sqrt(ep_r - 1.0);                        // ground impedance (horizontal polarization)
 

--- a/src/InitializePointToPoint.cpp
+++ b/src/InitializePointToPoint.cpp
@@ -22,8 +22,8 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-void InitializePointToPoint(double f__mhz, double h_sys__meter, double N_0, int pol, 
-    double epsilon, double sigma, complex<double> *Z_g, double *gamma_e, double *N_s)
+void InitializePointToPoint(const double f__mhz, const double h_sys__meter, const double N_0, const int pol, 
+    const double epsilon, const double sigma, complex<double> *Z_g, double *gamma_e, double *N_s)
 {
     // gamma_a is the curvature of the actual earth, ~1 / 6370 km
     double gamma_a = 157e-9;

--- a/src/InverseComplementaryCumulativeDistributionFunction.cpp
+++ b/src/InverseComplementaryCumulativeDistributionFunction.cpp
@@ -15,14 +15,14 @@
  |      Returns:  Q_q            - Q(q)^-1
  |
  *===========================================================================*/
-double InverseComplementaryCumulativeDistributionFunction(double q)
+double InverseComplementaryCumulativeDistributionFunction(const double q)
 {
-    double C_0 = 2.515516;
-    double C_1 = 0.802853;
-    double C_2 = 0.010328;
-    double D_1 = 1.432788;
-    double D_2 = 0.189269;
-    double D_3 = 0.001308;
+    const double C_0 = 2.515516;
+    const double C_1 = 0.802853;
+    const double C_2 = 0.010328;
+    const double D_1 = 1.432788;
+    const double D_2 = 0.189269;
+    const double D_3 = 0.001308;
 
     double x = q;
     if (q > 0.5)

--- a/src/InverseComplementaryCumulativeDistributionFunction.cpp
+++ b/src/InverseComplementaryCumulativeDistributionFunction.cpp
@@ -17,20 +17,20 @@
  *===========================================================================*/
 double InverseComplementaryCumulativeDistributionFunction(const double q)
 {
-    const double C_0 = 2.515516;
-    const double C_1 = 0.802853;
-    const double C_2 = 0.010328;
-    const double D_1 = 1.432788;
-    const double D_2 = 0.189269;
-    const double D_3 = 0.001308;
+    constexpr double C_0 = 2.515516;
+    constexpr double C_1 = 0.802853;
+    constexpr double C_2 = 0.010328;
+    constexpr double D_1 = 1.432788;
+    constexpr double D_2 = 0.189269;
+    constexpr double D_3 = 0.001308;
 
     double x = q;
     if (q > 0.5)
         x = 1.0 - x;
 
-    double T_x = sqrt(-2.0 * log(x));
+    const double T_x = sqrt(-2.0 * log(x));
 
-    double zeta_x = ((C_2 * T_x + C_1) * T_x + C_0) / (((D_3 * T_x + D_2) * T_x + D_1) * T_x + 1.0);
+    const double zeta_x = ((C_2 * T_x + C_1) * T_x + C_0) / (((D_3 * T_x + D_2) * T_x + D_1) * T_x + 1.0);
 
     double Q_q = T_x - zeta_x;
 

--- a/src/KnifeEdgeDiffraction.cpp
+++ b/src/KnifeEdgeDiffraction.cpp
@@ -15,7 +15,7 @@
  |      Returns:  A_k__db        - Knife-edge diffraction loss, in dB
  |
  *===========================================================================*/
-double KnifeEdgeDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, const double d_hzn__meter[2])
+double KnifeEdgeDiffraction(const double d__meter, const double f__mhz, const double a_e__meter, const double theta_los, const double d_hzn__meter[2])
 {
     double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];                         // Maximum line-of-sight distance for actual path
     double theta_nlos = d__meter / a_e__meter - theta_los;                          // Angular distance of diffraction region [Algorithm, Eqn 4.12]

--- a/src/KnifeEdgeDiffraction.cpp
+++ b/src/KnifeEdgeDiffraction.cpp
@@ -15,7 +15,7 @@
  |      Returns:  A_k__db        - Knife-edge diffraction loss, in dB
  |
  *===========================================================================*/
-double KnifeEdgeDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, double d_hzn__meter[2])
+double KnifeEdgeDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, const double d_hzn__meter[2])
 {
     double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];                         // Maximum line-of-sight distance for actual path
     double theta_nlos = d__meter / a_e__meter - theta_los;                          // Angular distance of diffraction region [Algorithm, Eqn 4.12]

--- a/src/KnifeEdgeDiffraction.cpp
+++ b/src/KnifeEdgeDiffraction.cpp
@@ -17,17 +17,17 @@
  *===========================================================================*/
 double KnifeEdgeDiffraction(const double d__meter, const double f__mhz, const double a_e__meter, const double theta_los, const double d_hzn__meter[2])
 {
-    double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];                         // Maximum line-of-sight distance for actual path
-    double theta_nlos = d__meter / a_e__meter - theta_los;                          // Angular distance of diffraction region [Algorithm, Eqn 4.12]
+    const double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];        // Maximum line-of-sight distance for actual path
+    const double theta_nlos = d__meter / a_e__meter - theta_los;         // Angular distance of diffraction region [Algorithm, Eqn 4.12]
 
-    double d_nlos__meter = d__meter - d_ML__meter;                                  // Diffraction distance, in meters
+    const double d_nlos__meter = d__meter - d_ML__meter;                 // Diffraction distance, in meters
 
     // 1 / (4 pi) = 0.0795775
     // [TN101, Eqn I.7]
-    double v_1 = 0.0795775 * (f__mhz / 47.7) * pow(theta_nlos, 2) * d_hzn__meter[0] * d_nlos__meter / (d_nlos__meter + d_hzn__meter[0]);
-    double v_2 = 0.0795775 * (f__mhz / 47.7) * pow(theta_nlos, 2) * d_hzn__meter[1] * d_nlos__meter / (d_nlos__meter + d_hzn__meter[1]);
+    const double v_1 = 0.0795775 * (f__mhz / 47.7) * pow(theta_nlos, 2) * d_hzn__meter[0] * d_nlos__meter / (d_nlos__meter + d_hzn__meter[0]);
+    const double v_2 = 0.0795775 * (f__mhz / 47.7) * pow(theta_nlos, 2) * d_hzn__meter[1] * d_nlos__meter / (d_nlos__meter + d_hzn__meter[1]);
 
-    double A_k__db = FresnelIntegral(v_1) + FresnelIntegral(v_2);                   // [TN101, Eqn I.1]
+    const double A_k__db = FresnelIntegral(v_1) + FresnelIntegral(v_2);  // [TN101, Eqn I.1]
 
     return A_k__db;
 }

--- a/src/LineOfSightLoss.cpp
+++ b/src/LineOfSightLoss.cpp
@@ -22,21 +22,21 @@
 double LineOfSightLoss(const double d__meter, const double h_e__meter[2], const complex<double> Z_g, const double delta_h__meter, 
     const double M_d, const double A_d0, const double d_sML__meter, const double f__mhz)
 {
-    double delta_h_d__meter = TerrainRoughness(d__meter, delta_h__meter);
+    const double delta_h_d__meter = TerrainRoughness(d__meter, delta_h__meter);
 
-    double sigma_h_d__meter = SigmaHFunction(delta_h_d__meter);
+    const double sigma_h_d__meter = SigmaHFunction(delta_h_d__meter);
 
     // wavenumber, k
-    double wn = f__mhz / 47.7;
+    const double wn = f__mhz / 47.7;
 
     // [Algorithm, Eqn 4.46]
-    double sin_psi = (h_e__meter[0] + h_e__meter[1]) / sqrt(pow(d__meter, 2) + pow(h_e__meter[0] + h_e__meter[1], 2));
+    const double sin_psi = (h_e__meter[0] + h_e__meter[1]) / sqrt(pow(d__meter, 2) + pow(h_e__meter[0] + h_e__meter[1], 2));
 
     // [Algorithm, Eqn 4.47]
     complex<double> R_e = (sin_psi - Z_g) / (sin_psi + Z_g) * exp(-MIN(10.0, wn * sigma_h_d__meter * sin_psi));
 
     // q = Magnitude of R_e', [Algorithm, Eqn 4.48]
-    double q = pow(R_e.real(), 2) + pow(R_e.imag(), 2);
+    const double q = pow(R_e.real(), 2) + pow(R_e.imag(), 2);
     if (q < 0.25 || q < sin_psi)
         R_e = R_e * sqrt(sin_psi / q);
 
@@ -48,16 +48,16 @@ double LineOfSightLoss(const double d__meter, const double h_e__meter[2], const 
         delta_phi = PI - pow(PI / 2.0, 2) / delta_phi;
 
     // Two-ray attenuation
-    complex<double> rr = complex<double>(cos(delta_phi), -sin(delta_phi)) + R_e;
-    double A_t__db = -10 * log10(pow(rr.real(), 2) + pow(rr.imag(), 2));
+    const complex<double> rr = complex<double>(cos(delta_phi), -sin(delta_phi)) + R_e;
+    const double A_t__db = -10 * log10(pow(rr.real(), 2) + pow(rr.imag(), 2));
 
     // Extended diffraction attenuation
-    double A_d__db = M_d * d__meter + A_d0;
+    const double A_d__db = M_d * d__meter + A_d0;
 
     // weighting factor
-    double w = 1 / (1 + f__mhz * delta_h__meter / MAX(10e3, d_sML__meter));
+    const double w = 1 / (1 + f__mhz * delta_h__meter / MAX(10e3, d_sML__meter));
 
-    double A_los__db = w * A_t__db + (1 - w) * A_d__db;
+    const double A_los__db = w * A_t__db + (1 - w) * A_d__db;
 
     return A_los__db;
 }

--- a/src/LineOfSightLoss.cpp
+++ b/src/LineOfSightLoss.cpp
@@ -19,8 +19,8 @@
  |      Returns:  A_los__db         - Loss, in dB
  |
  *===========================================================================*/
-double LineOfSightLoss(double d__meter, const double h_e__meter[2], complex<double> Z_g, double delta_h__meter, 
-    double M_d, double A_d0, double d_sML__meter, double f__mhz)
+double LineOfSightLoss(const double d__meter, const double h_e__meter[2], const complex<double> Z_g, const double delta_h__meter, 
+    const double M_d, const double A_d0, const double d_sML__meter, const double f__mhz)
 {
     double delta_h_d__meter = TerrainRoughness(d__meter, delta_h__meter);
 

--- a/src/LineOfSightLoss.cpp
+++ b/src/LineOfSightLoss.cpp
@@ -19,7 +19,7 @@
  |      Returns:  A_los__db         - Loss, in dB
  |
  *===========================================================================*/
-double LineOfSightLoss(double d__meter, double h_e__meter[2], complex<double> Z_g, double delta_h__meter, 
+double LineOfSightLoss(double d__meter, const double h_e__meter[2], complex<double> Z_g, double delta_h__meter, 
     double M_d, double A_d0, double d_sML__meter, double f__mhz)
 {
     double delta_h_d__meter = TerrainRoughness(d__meter, delta_h__meter);

--- a/src/LinearLeastSquaresFit.cpp
+++ b/src/LinearLeastSquaresFit.cpp
@@ -16,7 +16,7 @@
  *===========================================================================*/
 void LinearLeastSquaresFit(const double pfl[], const double d_start, const double d_end, double *fit_y1, double *fit_y2)
 {
-    int np = (int)pfl[0];
+    const int np = (int)pfl[0];
 
     int i_start = int(fdim(d_start / pfl[1], 0.0));
     int i_end = np - int(fdim(np, d_end / pfl[1]));
@@ -27,10 +27,10 @@ void LinearLeastSquaresFit(const double pfl[], const double d_start, const doubl
         i_end = np - (int)fdim(np, i_end + 1.0);
     }
 
-    double x_length = i_end - i_start;
+    const double x_length = i_end - i_start;
 
     double mid_shifted_index = -0.5 * x_length;
-    double mid_shifted_end = i_end + mid_shifted_index;
+    const double mid_shifted_end = i_end + mid_shifted_index;
 
     double sum_y = 0.5 * (pfl[i_start + 2] + pfl[i_end + 2]);
     double scaled_sum_y = 0.5 * (pfl[i_start + 2] - pfl[i_end + 2]) * mid_shifted_index;

--- a/src/LinearLeastSquaresFit.cpp
+++ b/src/LinearLeastSquaresFit.cpp
@@ -14,7 +14,7 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-void LinearLeastSquaresFit(const double pfl[], double d_start, double d_end, double *fit_y1, double *fit_y2)
+void LinearLeastSquaresFit(const double pfl[], const double d_start, const double d_end, double *fit_y1, double *fit_y2)
 {
     int np = (int)pfl[0];
 

--- a/src/LinearLeastSquaresFit.cpp
+++ b/src/LinearLeastSquaresFit.cpp
@@ -14,7 +14,7 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-void LinearLeastSquaresFit(double pfl[], double d_start, double d_end, double *fit_y1, double *fit_y2)
+void LinearLeastSquaresFit(const double pfl[], double d_start, double d_end, double *fit_y1, double *fit_y2)
 {
     int np = (int)pfl[0];
 

--- a/src/LongleyRice.cpp
+++ b/src/LongleyRice.cpp
@@ -32,7 +32,7 @@ int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<do
     const double d__meter, const int mode, double *A_ref__db, long *warnings, int *propmode)
 {
     // effective earth radius
-    double a_e__meter = 1 / gamma_e;
+    const double a_e__meter = 1 / gamma_e;
 
     double d_hzn_s__meter[2];
     // Terrestrial smooth earth horizon distance approximation
@@ -40,13 +40,13 @@ int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<do
         d_hzn_s__meter[i] = sqrt(2.0 * h_e__meter[i] * a_e__meter);
 
     // Maximum line-of-sight distance for smooth earth
-    double d_sML__meter = d_hzn_s__meter[0] + d_hzn_s__meter[1];
+    const double d_sML__meter = d_hzn_s__meter[0] + d_hzn_s__meter[1];
 
     // Maximum line-of-sight distance for actual path
-    double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];
+    const double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];
 
     // Angular distance of line-of-sight region
-    double theta_los = -MAX(theta_hzn[0] + theta_hzn[1], -d_ML__meter / a_e__meter);
+    const double theta_los = -MAX(theta_hzn[0] + theta_hzn[1], -d_ML__meter / a_e__meter);
 
     // Check validity of small angle approximation
     if (abs(theta_hzn[0]) > 200e-3)
@@ -83,18 +83,18 @@ int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<do
         return ERROR__GROUND_IMPEDANCE;
 
     // Select two distances far in the diffraction region
-    double d_3__meter = MAX(d_sML__meter, d_ML__meter + 5.0 * pow(pow(a_e__meter, 2) / f__mhz, 1.0 / 3.0));
-    double d_4__meter = d_3__meter + 10.0 * pow(pow(a_e__meter, 2) / f__mhz, 1.0 / 3.0);
+    const double d_3__meter = MAX(d_sML__meter, d_ML__meter + 5.0 * pow(pow(a_e__meter, 2) / f__mhz, 1.0 / 3.0));
+    const double d_4__meter = d_3__meter + 10.0 * pow(pow(a_e__meter, 2) / f__mhz, 1.0 / 3.0);
 
     // Compute the diffraction loss at the two distances
-    double A_3__db = DiffractionLoss(d_3__meter, d_hzn__meter, h_e__meter, Z_g, a_e__meter, delta_h__meter, h__meter, mode, theta_los, d_sML__meter, f__mhz);
-    double A_4__db = DiffractionLoss(d_4__meter, d_hzn__meter, h_e__meter, Z_g, a_e__meter, delta_h__meter, h__meter, mode, theta_los, d_sML__meter, f__mhz);
+    const double A_3__db = DiffractionLoss(d_3__meter, d_hzn__meter, h_e__meter, Z_g, a_e__meter, delta_h__meter, h__meter, mode, theta_los, d_sML__meter, f__mhz);
+    const double A_4__db = DiffractionLoss(d_4__meter, d_hzn__meter, h_e__meter, Z_g, a_e__meter, delta_h__meter, h__meter, mode, theta_los, d_sML__meter, f__mhz);
 
     // Compute the slope and intercept of the diffraction line
-    double M_d = (A_4__db - A_3__db) / (d_4__meter - d_3__meter);
-    double A_d0__db = A_3__db - M_d * d_3__meter;
+    const double M_d = (A_4__db - A_3__db) / (d_4__meter - d_3__meter);
+    const double A_d0__db = A_3__db - M_d * d_3__meter;
 
-    double d_min__meter = abs(h_e__meter[0] - h_e__meter[1]) / 200e-3;
+    const double d_min__meter = abs(h_e__meter[0] - h_e__meter[1]) / 200e-3;
 
     if (d__meter < d_min__meter)
         *warnings |= WARN__PATH_DISTANCE_TOO_SMALL_1;
@@ -109,7 +109,7 @@ int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<do
     if (d__meter < d_sML__meter)
     {
         // Compute the diffraction loss at the maximum smooth earth line of sight distance
-        double A_sML__db = d_sML__meter * M_d + A_d0__db;
+        const double A_sML__db = d_sML__meter * M_d + A_d0__db;
 
         // [ERL 79-ITS 67, Eqn 3.16a], in meters instead of km and with MIN() part below
         double d_0__meter = 0.04 * f__mhz * h_e__meter[0] * h_e__meter[1];
@@ -123,7 +123,7 @@ int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<do
         else
             d_1__meter = MAX(-A_d0__db / M_d, 0.25 * d_ML__meter);
 
-        double A_1__db = LineOfSightLoss(d_1__meter, h_e__meter, Z_g, delta_h__meter, M_d, A_d0__db, d_sML__meter, f__mhz);
+        const double A_1__db = LineOfSightLoss(d_1__meter, h_e__meter, Z_g, delta_h__meter, M_d, A_d0__db, d_sML__meter, f__mhz);
 
         bool flag = false;
 
@@ -132,9 +132,9 @@ int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<do
 
         if (d_0__meter < d_1__meter)
         {
-            double A_0__db = LineOfSightLoss(d_0__meter, h_e__meter, Z_g, delta_h__meter, M_d, A_d0__db, d_sML__meter, f__mhz);
+            const double A_0__db = LineOfSightLoss(d_0__meter, h_e__meter, Z_g, delta_h__meter, M_d, A_d0__db, d_sML__meter, f__mhz);
 
-            double q = log(d_sML__meter / d_0__meter);
+            const double q = log(d_sML__meter / d_0__meter);
 
             // [ERL 79-ITS 67, Eqn 3.20]
             kHat_2__db_per_meter = MAX(0.0, ((d_sML__meter - d_0__meter) * (A_1__db - A_0__db) - (d_1__meter - d_0__meter) * (A_sML__db - A_0__db)) / ((d_sML__meter - d_0__meter) * log(d_1__meter / d_0__meter) - (d_1__meter - d_0__meter) * q));
@@ -166,7 +166,7 @@ int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<do
                 kHat_1__db_per_meter = M_d;
         }
 
-        double A_o__db = A_sML__db - kHat_1__db_per_meter * d_sML__meter - kHat_2__db_per_meter * log(d_sML__meter);
+        const double A_o__db = A_sML__db - kHat_1__db_per_meter * d_sML__meter - kHat_2__db_per_meter * log(d_sML__meter);
 
         // [ERL 79-ITS 67, Eqn 3.19]
         *A_ref__db = A_o__db + kHat_1__db_per_meter * d__meter + kHat_2__db_per_meter * log(d__meter);
@@ -175,13 +175,13 @@ int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<do
     else // this is a trans-horizon path
     {
         // select to points far into the troposcatter region
-        double d_5__meter = d_ML__meter + 200e3;
-        double d_6__meter = d_ML__meter + 400e3;
+        const double d_5__meter = d_ML__meter + 200e3;
+        const double d_6__meter = d_ML__meter + 400e3;
 
         // Compute the troposcatter loss at the two distances
         double h0 = -1;
-        double A_6__db = TroposcatterLoss(d_6__meter, theta_hzn, d_hzn__meter, h_e__meter, a_e__meter, N_s, f__mhz, theta_los, &h0);
-        double A_5__db = TroposcatterLoss(d_5__meter, theta_hzn, d_hzn__meter, h_e__meter, a_e__meter, N_s, f__mhz, theta_los, &h0);
+        const double A_6__db = TroposcatterLoss(d_6__meter, theta_hzn, d_hzn__meter, h_e__meter, a_e__meter, N_s, f__mhz, theta_los, &h0);
+        const double A_5__db = TroposcatterLoss(d_5__meter, theta_hzn, d_hzn__meter, h_e__meter, a_e__meter, N_s, f__mhz, theta_los, &h0);
 
         double M_s, A_s0__db, d_x__meter;
 

--- a/src/LongleyRice.cpp
+++ b/src/LongleyRice.cpp
@@ -27,9 +27,9 @@
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int LongleyRice(double theta_hzn[2], double f__mhz, complex<double> Z_g, double d_hzn__meter[2], 
-    double h_e__meter[2], double gamma_e, double N_s, double delta_h__meter, const double h__meter[2], 
-    double d__meter, int mode, double *A_ref__db, long *warnings, int *propmode)
+int LongleyRice(const double theta_hzn[2], const double f__mhz, const complex<double> Z_g, const double d_hzn__meter[2], 
+    const double h_e__meter[2], const double gamma_e, const double N_s, const double delta_h__meter, const double h__meter[2], 
+    const double d__meter, const int mode, double *A_ref__db, long *warnings, int *propmode)
 {
     // effective earth radius
     double a_e__meter = 1 / gamma_e;

--- a/src/LongleyRice.cpp
+++ b/src/LongleyRice.cpp
@@ -28,7 +28,7 @@
  |
  *===========================================================================*/
 int LongleyRice(double theta_hzn[2], double f__mhz, complex<double> Z_g, double d_hzn__meter[2], 
-    double h_e__meter[2], double gamma_e, double N_s, double delta_h__meter, double h__meter[2], 
+    double h_e__meter[2], double gamma_e, double N_s, double delta_h__meter, const double h__meter[2], 
     double d__meter, int mode, double *A_ref__db, long *warnings, int *propmode)
 {
     // effective earth radius

--- a/src/QuickPfl.cpp
+++ b/src/QuickPfl.cpp
@@ -26,9 +26,9 @@ void QuickPfl(const double pfl[], const double gamma_e, const double h__meter[2]
 
     *d__meter = pfl[0] * pfl[1];
 
-    int np = int(pfl[0]);
+    const int np = int(pfl[0]);
 
-    double a_e__meter = 1 / gamma_e;        // effective earth radius
+    const double a_e__meter = 1 / gamma_e;        // effective earth radius
 
     FindHorizons(pfl, a_e__meter, h__meter, theta_hzn, d_hzn__meter);
 
@@ -52,7 +52,7 @@ void QuickPfl(const double pfl[], const double gamma_e, const double h__meter[2]
         for (int i = 0; i < 2; i++)
             d_hzn__meter[i] = sqrt(2.0 * h_e__meter[i] * a_e__meter) * exp(-0.07 * sqrt(*delta_h__meter / MAX(h_e__meter[i], 5.0)));
 
-        double combined_horizons__meter = d_hzn__meter[0] + d_hzn__meter[1];
+        const double combined_horizons__meter = d_hzn__meter[0] + d_hzn__meter[1];
         if (combined_horizons__meter <= *d__meter)
         {
             q = pow(*d__meter / combined_horizons__meter, 2);

--- a/src/QuickPfl.cpp
+++ b/src/QuickPfl.cpp
@@ -17,7 +17,7 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-void QuickPfl(double pfl[], double gamma_e, double h__meter[2], double theta_hzn[2], 
+void QuickPfl(const double pfl[], double gamma_e, const double h__meter[2], double theta_hzn[2], 
     double d_hzn__meter[2], double h_e__meter[2], double *delta_h__meter, double *d__meter)
 {
     double fit_tx, fit_rx, q;

--- a/src/QuickPfl.cpp
+++ b/src/QuickPfl.cpp
@@ -17,7 +17,7 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-void QuickPfl(const double pfl[], double gamma_e, const double h__meter[2], double theta_hzn[2], 
+void QuickPfl(const double pfl[], const double gamma_e, const double h__meter[2], double theta_hzn[2], 
     double d_hzn__meter[2], double h_e__meter[2], double *delta_h__meter, double *d__meter)
 {
     double fit_tx, fit_rx, q;

--- a/src/SigmaHFunction.cpp
+++ b/src/SigmaHFunction.cpp
@@ -11,7 +11,7 @@
  |      Returns:  sigma_h_meter  - sigma_h
  |
  *===========================================================================*/
-double SigmaHFunction(double delta_h__meter)
+double SigmaHFunction(const double delta_h__meter)
 {
     // "RMS deviation of terrain and terrain clutter within the limits of the first Fresnel zone in the dominant reflecting plane"
     // [ERL 79-ITS 67, Eqn 3.6a]

--- a/src/SmoothEarthDiffraction.cpp
+++ b/src/SmoothEarthDiffraction.cpp
@@ -29,8 +29,8 @@ double SmoothEarthDiffraction(const double d__meter, const double f__mhz, const 
     double x__km[3];
     double C_0[3];
 
-    double theta_nlos = d__meter / a_e__meter - theta_los;                          // [Algorithm, Eqn 4.12]
-    double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];                         // Maximum line-of-sight distance for actual path
+    const double theta_nlos = d__meter / a_e__meter - theta_los;                    // [Algorithm, Eqn 4.12]
+    const double d_ML__meter = d_hzn__meter[0] + d_hzn__meter[1];                   // Maximum line-of-sight distance for actual path
 
     // compute 3 radii
     a__meter[0] = (d__meter - d_ML__meter) / (d__meter / a_e__meter - theta_los);   // which is a_e__meter when theta_los = d_ML__meter / a_e__meter
@@ -65,7 +65,7 @@ double SmoothEarthDiffraction(const double d__meter, const double f__mhz, const 
     F_x__db[1] = HeightFunction(x__km[2], K[2]);
 
     // compute distance function
-    double G_x__db = 0.05751 * x__km[0] - 10.0 * log10(x__km[0]);                   // [TN101, Eqn 8.4] & [Volger 1964, Eqn 13]
+    const double G_x__db = 0.05751 * x__km[0] - 10.0 * log10(x__km[0]);             // [TN101, Eqn 8.4] & [Volger 1964, Eqn 13]
 
     return G_x__db - F_x__db[0] - F_x__db[1] - 20;                                  // [Algorithm, Eqn 4.20] & [Volger 1964]
 }

--- a/src/SmoothEarthDiffraction.cpp
+++ b/src/SmoothEarthDiffraction.cpp
@@ -18,8 +18,8 @@
  |      Returns:  A_r__db           - Smooth-earth diffraction loss, in dB
  |
  *===========================================================================*/
-double SmoothEarthDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, 
-    const double d_hzn__meter[2], const double h_e__meter[2], complex<double> Z_g)
+double SmoothEarthDiffraction(const double d__meter, const double f__mhz, const double a_e__meter, const double theta_los, 
+    const double d_hzn__meter[2], const double h_e__meter[2], const complex<double> Z_g)
 {
     double a__meter[3];
     double d__km[3];
@@ -82,7 +82,7 @@ double SmoothEarthDiffraction(double d__meter, double f__mhz, double a_e__meter,
  |      Returns:  F(x, K)        - in dB
  |
  *===========================================================================*/
-double HeightFunction(double x__km, double K)
+double HeightFunction(const double x__km, const double K)
 {
     double w;
     double result;

--- a/src/SmoothEarthDiffraction.cpp
+++ b/src/SmoothEarthDiffraction.cpp
@@ -19,7 +19,7 @@
  |
  *===========================================================================*/
 double SmoothEarthDiffraction(double d__meter, double f__mhz, double a_e__meter, double theta_los, 
-    double d_hzn__meter[2], double h_e__meter[2], complex<double> Z_g)
+    const double d_hzn__meter[2], const double h_e__meter[2], complex<double> Z_g)
 {
     double a__meter[3];
     double d__km[3];

--- a/src/TerrainRoughness.cpp
+++ b/src/TerrainRoughness.cpp
@@ -12,7 +12,7 @@
  |      Returns:  delta_h_d      - Terrain irregularity of path
  |
  *===========================================================================*/
-double TerrainRoughness(double d__meter, double delta_h__meter)
+double TerrainRoughness(const double d__meter, const double delta_h__meter)
 {
     // [ERL 79-ITS 67, Eqn 3], with distance in meters instead of kilometers
     return delta_h__meter * (1.0 - 0.8 * exp(-d__meter / 50e3));

--- a/src/TroposcatterLoss.cpp
+++ b/src/TroposcatterLoss.cpp
@@ -28,7 +28,7 @@ double FFunction(const double td)
     else                    // > 70 km
         i = 2;
 
-    double F_0 = a[i] + b[i] * td + c[i] * log10(td);     // [Algorithm, 6.9]
+    const double F_0 = a[i] + b[i] * td + c[i] * log10(td);  // [Algorithm, 6.9]
 
     return F_0;
 }
@@ -57,7 +57,7 @@ double TroposcatterLoss(const double d__meter, const double theta_hzn[2], const 
     double H_0;
 
     // wavenumber, k
-    double wn = f__mhz / 47.7;
+    const double wn = f__mhz / 47.7;
 
     if (*h0 > 15.0)     // short-circuit calculations if already greater than 15 dB
         H_0 = *h0;
@@ -72,11 +72,11 @@ double TroposcatterLoss(const double d__meter, const double theta_hzn[2], const 
             rr = 1.0 / rr;
         }
 
-        double theta = theta_hzn[0] + theta_hzn[1] + d__meter / a_e__meter;    // angular distance, in radians
+        const double theta = theta_hzn[0] + theta_hzn[1] + d__meter / a_e__meter;  // angular distance, in radians
 
         // [TN101, Eqn 9.4a]
-        double r_1 = 2.0 * wn * theta * h_e__meter[0];
-        double r_2 = 2.0 * wn * theta * h_e__meter[1];
+        const double r_1 = 2.0 * wn * theta * h_e__meter[0];
+        const double r_2 = 2.0 * wn * theta * h_e__meter[1];
 
         if (r_1 < 0.2 && r_2 < 0.2)
             return 1001;                // "If both r_1 and r_2 are less than 0.2 the function A_scat is not defined (or is infinite)" [Algorithm, page 11]
@@ -84,17 +84,17 @@ double TroposcatterLoss(const double d__meter, const double theta_hzn[2], const 
         double s = (d__meter - ad) / (d__meter + ad);       // asymmetry parameter
 
         // "In all of this, we truncate the values of s and q at 0.1 and 10" [Algorithm, page 16]
-        double q = MIN(MAX(0.1, rr / s), 10.0);             // TN101, Eqn 9.5
+        const double q = MIN(MAX(0.1, rr / s), 10.0);       // TN101, Eqn 9.5
         s = MAX(0.1, s);                                    // TN101, Eqn 9.5
 
         double h_0__meter = (d__meter - ad) * (d__meter + ad) * theta * 0.25 / d__meter;   // height of cross-over, [Algorithm, 4.66] [TN101v1, 9.3b]
 
-        double Z_0__meter = 1.7556e3;                       // Scale height, [Algorithm, 4.67]
-        double Z_1__meter = 8.0e3;                          // [Algorithm, 4.67]
-        double eta_s = (h_0__meter / Z_0__meter) * (1.0 + (0.031 - N_s * 2.32e-3 + pow(N_s, 2) * 5.67e-6) * exp(-pow(MIN(1.7, h_0__meter / Z_1__meter), 6)));     // Scattering efficiency factor, eta_s [TN101 Eqn 9.3a]
+        constexpr double Z_0__meter = 1.7556e3;             // Scale height, [Algorithm, 4.67]
+        constexpr double Z_1__meter = 8.0e3;                // [Algorithm, 4.67]
+        const double eta_s = (h_0__meter / Z_0__meter) * (1.0 + (0.031 - N_s * 2.32e-3 + pow(N_s, 2) * 5.67e-6) * exp(-pow(MIN(1.7, h_0__meter / Z_1__meter), 6)));  // Scattering efficiency factor, eta_s [TN101 Eqn 9.3a]
 
-        double H_00 = (H0Function(r_1, eta_s) + H0Function(r_2, eta_s)) / 2;                        // First term in TN101v1, Eqn 9.5
-        double Delta_H_0 = MIN(H_00, 6.0 * (0.6 - log10(MAX(eta_s, 1.0))) * log10(s) * log10(q));
+        const double H_00 = (H0Function(r_1, eta_s) + H0Function(r_2, eta_s)) / 2;                        // First term in TN101v1, Eqn 9.5
+        const double Delta_H_0 = MIN(H_00, 6.0 * (0.6 - log10(MAX(eta_s, 1.0))) * log10(s) * log10(q));
 
         H_0 = H_00 + Delta_H_0;                             // TN101, Eqn 9.5
         H_0 = MAX(H_0, 0.0);                                // "If Delta_H_0 would make H_0 negative, use H_0 = 0" [TN101v1, p9.4] 
@@ -108,9 +108,9 @@ double TroposcatterLoss(const double d__meter, const double theta_hzn[2], const 
     }
 
     *h0 = H_0;
-    double th = d__meter / a_e__meter - theta_los;
+    const double th = d__meter / a_e__meter - theta_los;
 
-    double D_0__meter = 40e3;   // [Algorithm, 6.8]
-    double H__meter = 47.7;     // [Algorithm, 4.63]
+    constexpr double D_0__meter = 40e3;   // [Algorithm, 6.8]
+    constexpr double H__meter = 47.7;     // [Algorithm, 4.63]
     return FFunction(th * d__meter) + 10 * log10(wn * H__meter * pow(th, 4)) - 0.1 * (N_s - 301.0) * exp(-th * d__meter / D_0__meter) + H_0;    // [Algorithm, 4.63]
 }

--- a/src/TroposcatterLoss.cpp
+++ b/src/TroposcatterLoss.cpp
@@ -11,7 +11,7 @@
  |      Returns:  F()            - in dB
  |
  *===========================================================================*/
-double FFunction(double td)
+double FFunction(const double td)
 {
     // constants from [Algorithm, 6.9]
     const double a[] = { 133.4, 104.6, 71.8 };
@@ -51,8 +51,8 @@ double FFunction(double td)
  |      Returns:  F()               - in dB
  |
  *===========================================================================*/
-double TroposcatterLoss(double d__meter, const double theta_hzn[2], const double d_hzn__meter[2], const double h_e__meter[2], 
-    double a_e__meter, double N_s, double f__mhz, double theta_los, double *h0)
+double TroposcatterLoss(const double d__meter, const double theta_hzn[2], const double d_hzn__meter[2], const double h_e__meter[2], 
+    const double a_e__meter, const double N_s, const double f__mhz, const double theta_los, double *h0)
 {
     double H_0;
 

--- a/src/TroposcatterLoss.cpp
+++ b/src/TroposcatterLoss.cpp
@@ -14,9 +14,9 @@
 double FFunction(double td)
 {
     // constants from [Algorithm, 6.9]
-    double a[] = { 133.4, 104.6, 71.8 };
-    double b[] = { 0.332e-3, 0.212e-3, 0.157e-3 };
-    double c[] = { -10, -2.5, 5 };
+    const double a[] = { 133.4, 104.6, 71.8 };
+    const double b[] = { 0.332e-3, 0.212e-3, 0.157e-3 };
+    const double c[] = { -10, -2.5, 5 };
 
     int i;
 
@@ -51,7 +51,7 @@ double FFunction(double td)
  |      Returns:  F()               - in dB
  |
  *===========================================================================*/
-double TroposcatterLoss(double d__meter, double theta_hzn[2], double d_hzn__meter[2], double h_e__meter[2], 
+double TroposcatterLoss(double d__meter, const double theta_hzn[2], const double d_hzn__meter[2], const double h_e__meter[2], 
     double a_e__meter, double N_s, double f__mhz, double theta_los, double *h0)
 {
     double H_0;

--- a/src/ValidateInputs.cpp
+++ b/src/ValidateInputs.cpp
@@ -36,9 +36,9 @@
  |      Returns:  [None]
  |
  *===========================================================================*/
-int ValidateInputs(double h_tx__meter, double h_rx__meter, int climate, double time,
-    double location, double situation, double N_0, double f__mhz, int pol,
-    double epsilon, double sigma, int mdvar, long *warnings)
+int ValidateInputs(const double h_tx__meter, const double h_rx__meter, const int climate, const double time,
+    const double location, const double situation, const double N_0, const double f__mhz, const int pol,
+    const double epsilon, const double sigma, const int mdvar, long *warnings)
 {
     if (h_tx__meter < 1.0 || h_tx__meter > 1000.0)
         *warnings |= WARN__TX_TERMINAL_HEIGHT;

--- a/src/Variability.cpp
+++ b/src/Variability.cpp
@@ -47,7 +47,7 @@ double Curve(const double c1, const double c2, const double x1, const double x2,
  |
  *===========================================================================*/
 double Variability(const double time, const double location, const double situation, const double h_e__meter[2], const double delta_h__meter, 
-    const double f__mhz, const double d__meter, const double A_ref__db, int climate, const int mdvar, long *warnings)
+    const double f__mhz, const double d__meter, const double A_ref__db, const int climate, const int mdvar, long *warnings)
 {
     // Asymptotic values from TN101, Fig 10.13
     // -> approximate to TN101v2 Eqn III.69 & III.70
@@ -88,7 +88,8 @@ double Variability(const double time, const double location, const double situat
     double z_L = InverseComplementaryCumulativeDistributionFunction(location / 100);
     const double z_S = InverseComplementaryCumulativeDistributionFunction(situation / 100);
 
-    climate--; // 0-based indexes
+    int climate_idx = climate; // Create an internal copy for modification
+    climate_idx--; // 0-based indexes
 
     const double wn = f__mhz / 47.7;
 
@@ -129,7 +130,7 @@ double Variability(const double time, const double location, const double situat
     if (plus10)
         mdvar_internal -= 10;
 
-    const double V_med__db = Curve(all_year[0][climate], all_year[1][climate], all_year[2][climate], all_year[3][climate], all_year[4][climate], d_e__meter);
+    const double V_med__db = Curve(all_year[0][climate_idx], all_year[1][climate_idx], all_year[2][climate_idx], all_year[3][climate_idx], all_year[4][climate_idx], d_e__meter);
 
     if (mdvar_internal == SINGLE_MESSAGE_MODE)
     {
@@ -166,19 +167,19 @@ double Variability(const double time, const double location, const double situat
     // time variability calcs
 
     const double q = log(0.133 * wn);
-    const double g_minus = bfm1[climate] + bfm2[climate] / (pow(bfm3[climate] * q, 2) + 1.0);
-    const double g_plus = bfp1[climate] + bfp2[climate] / (pow(bfp3[climate] * q, 2) + 1.0);
+    const double g_minus = bfm1[climate_idx] + bfm2[climate_idx] / (pow(bfm3[climate_idx] * q, 2) + 1.0);
+    const double g_plus = bfp1[climate_idx] + bfp2[climate_idx] / (pow(bfp3[climate_idx] * q, 2) + 1.0);
 
-    const double sigma_T_minus = Curve(bsm1[climate], bsm2[climate], xsm1[climate], xsm2[climate], xsm3[climate], d_e__meter) * g_minus;
-    const double sigma_T_plus = Curve(bsp1[climate], bsp2[climate], xsp1[climate], xsp2[climate], xsp3[climate], d_e__meter) * g_plus;
+    const double sigma_T_minus = Curve(bsm1[climate_idx], bsm2[climate_idx], xsm1[climate_idx], xsm2[climate_idx], xsm3[climate_idx], d_e__meter) * g_minus;
+    const double sigma_T_plus = Curve(bsp1[climate_idx], bsp2[climate_idx], xsp1[climate_idx], xsp2[climate_idx], xsp3[climate_idx], d_e__meter) * g_plus;
 
-    const double sigma_TD = C_D[climate] * sigma_T_plus;
-    const double tgtd = (sigma_T_plus - sigma_TD) * z_D[climate];
+    const double sigma_TD = C_D[climate_idx] * sigma_T_plus;
+    const double tgtd = (sigma_T_plus - sigma_TD) * z_D[climate_idx];
 
     double sigma_T;
     if (z_T < 0.0)
         sigma_T = sigma_T_minus;
-    else if (z_T <= z_D[climate])
+    else if (z_T <= z_D[climate_idx])
         sigma_T = sigma_T_plus;
     else
         sigma_T = sigma_TD + tgtd / z_T;

--- a/src/Variability.cpp
+++ b/src/Variability.cpp
@@ -52,7 +52,7 @@ double Variability(const double time, const double location, const double situat
     // Asymptotic values from TN101, Fig 10.13
     // -> approximate to TN101v2 Eqn III.69 & III.70
     // -> to describe the curves for each climate
-    const double all_year[5][7] =
+    constexpr double all_year[5][7] =
     {
         {  -9.67,   -0.62,    1.26,   -9.21,   -0.62,   -0.39,      3.15 },
         {  12.7,     9.19,   15.5,     9.05,    9.19,    2.86,   857.9   },
@@ -61,39 +61,39 @@ double Variability(const double time, const double location, const double situat
         { 133.8e3, 143.6e3,  99.8e3,  98.6e3, 143.6e3, 167.4e3,  116.3e3 }
     };
 
-    const double bsm1[] = { 2.13,      2.66,    6.11,     1.98,   2.68,    6.86,    8.51 };
-    const double bsm2[] = { 159.5,     7.67,    6.65,    13.11,   7.16,   10.38,  169.8 };
-    const double xsm1[] = { 762.2e3, 100.4e3, 138.2e3, 139.1e3,  93.7e3, 187.8e3, 609.8e3 };
-    const double xsm2[] = { 123.6e3, 172.5e3, 242.2e3, 132.7e3, 186.8e3, 169.6e3, 119.9e3 };
-    const double xsm3[] = { 94.5e3,  136.4e3, 178.6e3, 193.5e3, 133.5e3, 108.9e3, 106.6e3 };
+    constexpr double bsm1[] = { 2.13,      2.66,    6.11,     1.98,   2.68,    6.86,    8.51 };
+    constexpr double bsm2[] = { 159.5,     7.67,    6.65,    13.11,   7.16,   10.38,  169.8 };
+    constexpr double xsm1[] = { 762.2e3, 100.4e3, 138.2e3, 139.1e3,  93.7e3, 187.8e3, 609.8e3 };
+    constexpr double xsm2[] = { 123.6e3, 172.5e3, 242.2e3, 132.7e3, 186.8e3, 169.6e3, 119.9e3 };
+    constexpr double xsm3[] = { 94.5e3,  136.4e3, 178.6e3, 193.5e3, 133.5e3, 108.9e3, 106.6e3 };
 
-    const double bsp1[] = { 2.11, 6.87, 10.08, 3.68, 4.75, 8.58, 8.43 };
-    const double bsp2[] = { 102.3, 15.53, 9.60, 159.3, 8.12, 13.97, 8.19 };
-    const double xsp1[] = { 636.9e3, 138.7e3, 165.3e3, 464.4e3, 93.2e3, 216.0e3, 136.2e3 };
-    const double xsp2[] = { 134.8e3, 143.7e3, 225.7e3, 93.1e3, 135.9e3, 152.0e3, 188.5e3 };
-    const double xsp3[] = { 95.6e3, 98.6e3, 129.7e3, 94.2e3, 113.4e3, 122.7e3, 122.9e3 };
+    constexpr double bsp1[] = { 2.11, 6.87, 10.08, 3.68, 4.75, 8.58, 8.43 };
+    constexpr double bsp2[] = { 102.3, 15.53, 9.60, 159.3, 8.12, 13.97, 8.19 };
+    constexpr double xsp1[] = { 636.9e3, 138.7e3, 165.3e3, 464.4e3, 93.2e3, 216.0e3, 136.2e3 };
+    constexpr double xsp2[] = { 134.8e3, 143.7e3, 225.7e3, 93.1e3, 135.9e3, 152.0e3, 188.5e3 };
+    constexpr double xsp3[] = { 95.6e3, 98.6e3, 129.7e3, 94.2e3, 113.4e3, 122.7e3, 122.9e3 };
 
-    const double C_D[] = { 1.224, 0.801, 1.380, 1.000, 1.224, 1.518, 1.518 };	    // [Algorithm, Table 5.1], C_d
-    const double z_D[] = { 1.282, 2.161, 1.282, 20.0, 1.282, 1.282, 1.282 };		// [Algorithm, Table 5.1], z_d
+    constexpr double C_D[] = { 1.224, 0.801, 1.380, 1.000, 1.224, 1.518, 1.518 };	// [Algorithm, Table 5.1], C_d
+    constexpr double z_D[] = { 1.282, 2.161, 1.282, 20.0, 1.282, 1.282, 1.282 };	// [Algorithm, Table 5.1], z_d
 
-    const double bfm1[] = { 1.0, 1.0, 1.0, 1.0, 0.92, 1.0, 1.0 };
-    const double bfm2[] = { 0.0, 0.0, 0.0, 0.0, 0.25, 0.0, 0.0 };
-    const double bfm3[] = { 0.0, 0.0, 0.0, 0.0, 1.77, 0.0, 0.0 };
+    constexpr double bfm1[] = { 1.0, 1.0, 1.0, 1.0, 0.92, 1.0, 1.0 };
+    constexpr double bfm2[] = { 0.0, 0.0, 0.0, 0.0, 0.25, 0.0, 0.0 };
+    constexpr double bfm3[] = { 0.0, 0.0, 0.0, 0.0, 1.77, 0.0, 0.0 };
 
-    const double bfp1[] = { 1.0, 0.93, 1.0, 0.93, 0.93, 1.0, 1.0 };
-    const double bfp2[] = { 0.0, 0.31, 0.0, 0.19, 0.31, 0.0, 0.0 };
-    const double bfp3[] = { 0.0, 2.00, 0.0, 1.79, 2.00, 0.0, 0.0 };
+    constexpr double bfp1[] = { 1.0, 0.93, 1.0, 0.93, 0.93, 1.0, 1.0 };
+    constexpr double bfp2[] = { 0.0, 0.31, 0.0, 0.19, 0.31, 0.0, 0.0 };
+    constexpr double bfp3[] = { 0.0, 2.00, 0.0, 1.79, 2.00, 0.0, 0.0 };
 
     double z_T = InverseComplementaryCumulativeDistributionFunction(time / 100);
     double z_L = InverseComplementaryCumulativeDistributionFunction(location / 100);
-    double z_S = InverseComplementaryCumulativeDistributionFunction(situation / 100);
+    const double z_S = InverseComplementaryCumulativeDistributionFunction(situation / 100);
 
     climate--; // 0-based indexes
 
-    double wn = f__mhz / 47.7;
+    const double wn = f__mhz / 47.7;
 
     // compute the effective distance
-    double d_ex__meter = sqrt(2 * a_9000__meter * h_e__meter[0]) + sqrt(2 * a_9000__meter * h_e__meter[1]) + pow((575.7e12 / wn), THIRD);		// [Algorithm, Eqn 5.3]
+    const double d_ex__meter = sqrt(2 * a_9000__meter * h_e__meter[0]) + sqrt(2 * a_9000__meter * h_e__meter[1]) + pow((575.7e12 / wn), THIRD);  // [Algorithm, Eqn 5.3]
 
     double d_e__meter;
     if (d__meter < d_ex__meter)
@@ -107,7 +107,7 @@ double Variability(const double time, const double location, const double situat
     // if mdvar >= 20, then "Direct situation variability is to be eliminated as it should when
     //                       considering interference problems.  Note that there may still be a 
     //                       small residual situation variability" [Hufford, 1982]
-    bool plus20 = mdvar >= 20;
+    const bool plus20 = mdvar >= 20;
     if (plus20)
         mdvar -= 20;
 
@@ -124,11 +124,11 @@ double Variability(const double time, const double location, const double situat
     //////////////////////////////////
 
     
-    bool plus10 = mdvar >= 10;
+    const bool plus10 = mdvar >= 10;
     if (plus10)
         mdvar -= 10;
 
-    double V_med__db = Curve(all_year[0][climate], all_year[1][climate], all_year[2][climate], all_year[3][climate], all_year[4][climate], d_e__meter);
+    const double V_med__db = Curve(all_year[0][climate], all_year[1][climate], all_year[2][climate], all_year[3][climate], all_year[4][climate], d_e__meter);
 
     if (mdvar == SINGLE_MESSAGE_MODE)
     {
@@ -152,11 +152,11 @@ double Variability(const double time, const double location, const double situat
         sigma_L = 0.0;
     else
     {
-        double delta_h_d__meter = TerrainRoughness(d__meter, delta_h__meter);
+        const double delta_h_d__meter = TerrainRoughness(d__meter, delta_h__meter);
 
         sigma_L = 10.0 * wn * delta_h_d__meter / (wn * delta_h_d__meter + 13.0);    // Context of [Algorithm, Eqn 5.9]
     }
-    double Y_L = sigma_L * z_L;
+    const double Y_L = sigma_L * z_L;
 
     //
     //////////////////////////////////
@@ -164,15 +164,15 @@ double Variability(const double time, const double location, const double situat
     //////////////////////////////////
     // time variability calcs
 
-    double q = log(0.133 * wn);
-    double g_minus = bfm1[climate] + bfm2[climate] / (pow(bfm3[climate] * q, 2) + 1.0);
-    double g_plus = bfp1[climate] + bfp2[climate] / (pow(bfp3[climate] * q, 2) + 1.0);
+    const double q = log(0.133 * wn);
+    const double g_minus = bfm1[climate] + bfm2[climate] / (pow(bfm3[climate] * q, 2) + 1.0);
+    const double g_plus = bfp1[climate] + bfp2[climate] / (pow(bfp3[climate] * q, 2) + 1.0);
 
-    double sigma_T_minus = Curve(bsm1[climate], bsm2[climate], xsm1[climate], xsm2[climate], xsm3[climate], d_e__meter) * g_minus;
-    double sigma_T_plus = Curve(bsp1[climate], bsp2[climate], xsp1[climate], xsp2[climate], xsp3[climate], d_e__meter) * g_plus;
+    const double sigma_T_minus = Curve(bsm1[climate], bsm2[climate], xsm1[climate], xsm2[climate], xsm3[climate], d_e__meter) * g_minus;
+    const double sigma_T_plus = Curve(bsp1[climate], bsp2[climate], xsp1[climate], xsp2[climate], xsp3[climate], d_e__meter) * g_plus;
 
-    double sigma_TD = C_D[climate] * sigma_T_plus;
-    double tgtd = (sigma_T_plus - sigma_TD) * z_D[climate];
+    const double sigma_TD = C_D[climate] * sigma_T_plus;
+    const double tgtd = (sigma_T_plus - sigma_TD) * z_D[climate];
 
     double sigma_T;
     if (z_T < 0.0)
@@ -181,12 +181,12 @@ double Variability(const double time, const double location, const double situat
         sigma_T = sigma_T_plus;
     else
         sigma_T = sigma_TD + tgtd / z_T;
-    double Y_T = sigma_T * z_T;
+    const double Y_T = sigma_T * z_T;
 
     //
     /////////////////////////////////
 
-    double Y_S_temp = pow(sigma_S, 2) + pow(Y_T, 2) / (7.8 + pow(z_S, 2)) + pow(Y_L, 2) / (24.0 + pow(z_S, 2));   // Part of [Algorithm, Eqn 5.11]
+    const double Y_S_temp = pow(sigma_S, 2) + pow(Y_T, 2) / (7.8 + pow(z_S, 2)) + pow(Y_L, 2) / (24.0 + pow(z_S, 2));  // Part of [Algorithm, Eqn 5.11]
 
     double Y_R, Y_S;
     if (mdvar == SINGLE_MESSAGE_MODE)

--- a/src/Variability.cpp
+++ b/src/Variability.cpp
@@ -47,7 +47,7 @@ double Curve(const double c1, const double c2, const double x1, const double x2,
  |
  *===========================================================================*/
 double Variability(const double time, const double location, const double situation, const double h_e__meter[2], const double delta_h__meter, 
-    const double f__mhz, const double d__meter, const double A_ref__db, int climate, int mdvar, long *warnings)
+    const double f__mhz, const double d__meter, const double A_ref__db, int climate, const int mdvar, long *warnings)
 {
     // Asymptotic values from TN101, Fig 10.13
     // -> approximate to TN101v2 Eqn III.69 & III.70
@@ -107,9 +107,10 @@ double Variability(const double time, const double location, const double situat
     // if mdvar >= 20, then "Direct situation variability is to be eliminated as it should when
     //                       considering interference problems.  Note that there may still be a 
     //                       small residual situation variability" [Hufford, 1982]
-    const bool plus20 = mdvar >= 20;
+    int mdvar_internal = mdvar;  // Create an internal copy to modify
+    const bool plus20 = mdvar_internal >= 20;
     if (plus20)
-        mdvar -= 20;
+        mdvar_internal -= 20;
 
     double sigma_S;
     if (plus20)
@@ -124,20 +125,20 @@ double Variability(const double time, const double location, const double situat
     //////////////////////////////////
 
     
-    const bool plus10 = mdvar >= 10;
+    const bool plus10 = mdvar_internal >= 10;
     if (plus10)
-        mdvar -= 10;
+        mdvar_internal -= 10;
 
     const double V_med__db = Curve(all_year[0][climate], all_year[1][climate], all_year[2][climate], all_year[3][climate], all_year[4][climate], d_e__meter);
 
-    if (mdvar == SINGLE_MESSAGE_MODE)
+    if (mdvar_internal == SINGLE_MESSAGE_MODE)
     {
         z_T = z_S;
         z_L = z_S;
     }
-    else if (mdvar == ACCIDENTAL_MODE)
+    else if (mdvar_internal == ACCIDENTAL_MODE)
         z_L = z_S;
-    else if (mdvar == MOBILE_MODE)
+    else if (mdvar_internal == MOBILE_MODE)
         z_L = z_T;
     // else using Broadcast Mode (no additional operations)
 
@@ -189,17 +190,17 @@ double Variability(const double time, const double location, const double situat
     const double Y_S_temp = pow(sigma_S, 2) + pow(Y_T, 2) / (7.8 + pow(z_S, 2)) + pow(Y_L, 2) / (24.0 + pow(z_S, 2));  // Part of [Algorithm, Eqn 5.11]
 
     double Y_R, Y_S;
-    if (mdvar == SINGLE_MESSAGE_MODE)
+    if (mdvar_internal == SINGLE_MESSAGE_MODE)
     {
         Y_R = 0.0;
         Y_S = sqrt(pow(sigma_T, 2) + pow(sigma_L, 2) + Y_S_temp) * z_S;
     }
-    else if (mdvar == ACCIDENTAL_MODE)
+    else if (mdvar_internal == ACCIDENTAL_MODE)
     {
         Y_R = Y_T;
         Y_S = sqrt(pow(sigma_L, 2) + Y_S_temp) * z_S;
     }
-    else if (mdvar == MOBILE_MODE)
+    else if (mdvar_internal == MOBILE_MODE)
     {
         Y_R = sqrt(pow(sigma_T, 2) + pow(sigma_L, 2)) * z_T;
         Y_S = sqrt(Y_S_temp) * z_S;

--- a/src/Variability.cpp
+++ b/src/Variability.cpp
@@ -14,7 +14,7 @@
  |      Returns:  Curve value           - in dB
  |
  *===========================================================================*/
-double Curve(double c1, double c2, double x1, double x2, double x3, double d_e__meter)
+double Curve(const double c1, const double c2, const double x1, const double x2, const double x3, const double d_e__meter)
 {
     return (c1 + c2 / (1.0 + pow((d_e__meter - x2) / x3, 2))) * (pow(d_e__meter / x1, 2)) / (1.0 + (pow(d_e__meter / x1, 2)));
 }
@@ -46,8 +46,8 @@ double Curve(double c1, double c2, double x1, double x2, double x3, double d_e__
  |      Returns:  F()            - in dB
  |
  *===========================================================================*/
-double Variability(double time, double location, double situation, const double h_e__meter[2], double delta_h__meter, 
-    double f__mhz, double d__meter, double A_ref__db, int climate, int mdvar, long *warnings)
+double Variability(const double time, const double location, const double situation, const double h_e__meter[2], const double delta_h__meter, 
+    const double f__mhz, const double d__meter, const double A_ref__db, int climate, int mdvar, long *warnings)
 {
     // Asymptotic values from TN101, Fig 10.13
     // -> approximate to TN101v2 Eqn III.69 & III.70

--- a/src/Variability.cpp
+++ b/src/Variability.cpp
@@ -84,9 +84,9 @@ double Variability(const double time, const double location, const double situat
     const double bfp2[] = { 0.0, 0.31, 0.0, 0.19, 0.31, 0.0, 0.0 };
     const double bfp3[] = { 0.0, 2.00, 0.0, 1.79, 2.00, 0.0, 0.0 };
 
-    double z_T = InverseComplementaryCumulativeDistributionFunction(time);
-    double z_L = InverseComplementaryCumulativeDistributionFunction(location);
-    double z_S = InverseComplementaryCumulativeDistributionFunction(situation);
+    double z_T = InverseComplementaryCumulativeDistributionFunction(time / 100);
+    double z_L = InverseComplementaryCumulativeDistributionFunction(location / 100);
+    double z_S = InverseComplementaryCumulativeDistributionFunction(situation / 100);
 
     climate--; // 0-based indexes
 

--- a/src/Variability.cpp
+++ b/src/Variability.cpp
@@ -46,13 +46,13 @@ double Curve(double c1, double c2, double x1, double x2, double x3, double d_e__
  |      Returns:  F()            - in dB
  |
  *===========================================================================*/
-double Variability(double time, double location, double situation, double h_e__meter[2], double delta_h__meter, 
+double Variability(double time, double location, double situation, const double h_e__meter[2], double delta_h__meter, 
     double f__mhz, double d__meter, double A_ref__db, int climate, int mdvar, long *warnings)
 {
     // Asymptotic values from TN101, Fig 10.13
     // -> approximate to TN101v2 Eqn III.69 & III.70
     // -> to describe the curves for each climate
-    double all_year[5][7] =
+    const double all_year[5][7] =
     {
         {  -9.67,   -0.62,    1.26,   -9.21,   -0.62,   -0.39,      3.15 },
         {  12.7,     9.19,   15.5,     9.05,    9.19,    2.86,   857.9   },
@@ -61,28 +61,28 @@ double Variability(double time, double location, double situation, double h_e__m
         { 133.8e3, 143.6e3,  99.8e3,  98.6e3, 143.6e3, 167.4e3,  116.3e3 }
     };
 
-    double bsm1[] = { 2.13,      2.66,    6.11,     1.98,   2.68,    6.86,    8.51 };
-    double bsm2[] = { 159.5,     7.67,    6.65,    13.11,   7.16,   10.38,  169.8 };
-    double xsm1[] = { 762.2e3, 100.4e3, 138.2e3, 139.1e3,  93.7e3, 187.8e3, 609.8e3 };
-    double xsm2[] = { 123.6e3, 172.5e3, 242.2e3, 132.7e3, 186.8e3, 169.6e3, 119.9e3 };
-    double xsm3[] = { 94.5e3,  136.4e3, 178.6e3, 193.5e3, 133.5e3, 108.9e3, 106.6e3 };
+    const double bsm1[] = { 2.13,      2.66,    6.11,     1.98,   2.68,    6.86,    8.51 };
+    const double bsm2[] = { 159.5,     7.67,    6.65,    13.11,   7.16,   10.38,  169.8 };
+    const double xsm1[] = { 762.2e3, 100.4e3, 138.2e3, 139.1e3,  93.7e3, 187.8e3, 609.8e3 };
+    const double xsm2[] = { 123.6e3, 172.5e3, 242.2e3, 132.7e3, 186.8e3, 169.6e3, 119.9e3 };
+    const double xsm3[] = { 94.5e3,  136.4e3, 178.6e3, 193.5e3, 133.5e3, 108.9e3, 106.6e3 };
 
-    double bsp1[] = { 2.11, 6.87, 10.08, 3.68, 4.75, 8.58, 8.43 };
-    double bsp2[] = { 102.3, 15.53, 9.60, 159.3, 8.12, 13.97, 8.19 };
-    double xsp1[] = { 636.9e3, 138.7e3, 165.3e3, 464.4e3, 93.2e3, 216.0e3, 136.2e3 };
-    double xsp2[] = { 134.8e3, 143.7e3, 225.7e3, 93.1e3, 135.9e3, 152.0e3, 188.5e3 };
-    double xsp3[] = { 95.6e3, 98.6e3, 129.7e3, 94.2e3, 113.4e3, 122.7e3, 122.9e3 };
+    const double bsp1[] = { 2.11, 6.87, 10.08, 3.68, 4.75, 8.58, 8.43 };
+    const double bsp2[] = { 102.3, 15.53, 9.60, 159.3, 8.12, 13.97, 8.19 };
+    const double xsp1[] = { 636.9e3, 138.7e3, 165.3e3, 464.4e3, 93.2e3, 216.0e3, 136.2e3 };
+    const double xsp2[] = { 134.8e3, 143.7e3, 225.7e3, 93.1e3, 135.9e3, 152.0e3, 188.5e3 };
+    const double xsp3[] = { 95.6e3, 98.6e3, 129.7e3, 94.2e3, 113.4e3, 122.7e3, 122.9e3 };
 
-    double C_D[] = { 1.224, 0.801, 1.380, 1.000, 1.224, 1.518, 1.518 };	    // [Algorithm, Table 5.1], C_d
-    double z_D[] = { 1.282, 2.161, 1.282, 20.0, 1.282, 1.282, 1.282 };		// [Algorithm, Table 5.1], z_d
+    const double C_D[] = { 1.224, 0.801, 1.380, 1.000, 1.224, 1.518, 1.518 };	    // [Algorithm, Table 5.1], C_d
+    const double z_D[] = { 1.282, 2.161, 1.282, 20.0, 1.282, 1.282, 1.282 };		// [Algorithm, Table 5.1], z_d
 
-    double bfm1[] = { 1.0, 1.0, 1.0, 1.0, 0.92, 1.0, 1.0 };
-    double bfm2[] = { 0.0, 0.0, 0.0, 0.0, 0.25, 0.0, 0.0 };
-    double bfm3[] = { 0.0, 0.0, 0.0, 0.0, 1.77, 0.0, 0.0 };
+    const double bfm1[] = { 1.0, 1.0, 1.0, 1.0, 0.92, 1.0, 1.0 };
+    const double bfm2[] = { 0.0, 0.0, 0.0, 0.0, 0.25, 0.0, 0.0 };
+    const double bfm3[] = { 0.0, 0.0, 0.0, 0.0, 1.77, 0.0, 0.0 };
 
-    double bfp1[] = { 1.0, 0.93, 1.0, 0.93, 0.93, 1.0, 1.0 };
-    double bfp2[] = { 0.0, 0.31, 0.0, 0.19, 0.31, 0.0, 0.0 };
-    double bfp3[] = { 0.0, 2.00, 0.0, 1.79, 2.00, 0.0, 0.0 };
+    const double bfp1[] = { 1.0, 0.93, 1.0, 0.93, 0.93, 1.0, 1.0 };
+    const double bfp2[] = { 0.0, 0.31, 0.0, 0.19, 0.31, 0.0, 0.0 };
+    const double bfp3[] = { 0.0, 2.00, 0.0, 1.79, 2.00, 0.0, 0.0 };
 
     double z_T = InverseComplementaryCumulativeDistributionFunction(time);
     double z_L = InverseComplementaryCumulativeDistributionFunction(location);

--- a/src/itm_area.cpp
+++ b/src/itm_area.cpp
@@ -142,7 +142,7 @@ int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const in
 
     InitializeArea(site_criteria, gamma_e, delta_h__meter, h__meter, h_e__meter, d_hzn__meter, theta_hzn);
 
-    double d__meter = d__km * 1000;
+    const double d__meter = d__km * 1000;
     int propmode = MODE__NOT_SET;
     rtn = LongleyRice(theta_hzn, f__mhz, Z_g, d_hzn__meter, h_e__meter, gamma_e, N_s, delta_h__meter, h__meter, d__meter, MODE__AREA, 
         &A_ref__db, warnings, &propmode);

--- a/src/itm_area.cpp
+++ b/src/itm_area.cpp
@@ -48,7 +48,7 @@
  *===========================================================================*/
 int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings)
+    const int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings)
 {
     IntermediateValues interValues;
 
@@ -103,7 +103,7 @@ int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int t
  *===========================================================================*/
 int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km, 
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma, 
-    int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings, IntermediateValues *interValues)
+    const int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings, IntermediateValues *interValues)
 {
     *warnings = NO_WARNINGS;
 
@@ -217,7 +217,7 @@ int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const in
  *===========================================================================*/
 int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, const double confidence, const double reliability, double *A__db, long *warnings)
+    const int mdvar, const double confidence, const double reliability, double *A__db, long *warnings)
 {
     IntermediateValues interValues;
 
@@ -280,7 +280,7 @@ int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx
  *===========================================================================*/
 int ITM_AREA_CR_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, const double confidence, const double reliability, double *A__db, long *warnings, IntermediateValues *interValues)
+    const int mdvar, const double confidence, const double reliability, double *A__db, long *warnings, IntermediateValues *interValues)
 {
     int rtn = ITM_AREA_TLS_Ex(h_tx__meter, h_rx__meter, tx_site_criteria, rx_site_criteria, d__km,
         delta_h__meter, climate, N_0, f__mhz, pol, epsilon, sigma,

--- a/src/itm_area.cpp
+++ b/src/itm_area.cpp
@@ -131,8 +131,8 @@ int ITM_AREA_TLS_Ex(double h_tx__meter, double h_rx__meter, int tx_site_criteria
         rx_site_criteria != SITING_CRITERIA__VERY_CAREFUL)
         return ERROR__RX_SITING_CRITERIA;
 
-    int site_criteria[2] = { tx_site_criteria, rx_site_criteria };
-    double h__meter[2] = { h_tx__meter, h_rx__meter };
+    const int site_criteria[2] = { tx_site_criteria, rx_site_criteria };
+    const double h__meter[2] = { h_tx__meter, h_rx__meter };
     interValues->d__km = d__km;
 
     double theta_hzn[2];

--- a/src/itm_area.cpp
+++ b/src/itm_area.cpp
@@ -48,7 +48,7 @@
  *===========================================================================*/
 int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, double time, double location, double situation, double *A__db, long *warnings)
+    int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings)
 {
     IntermediateValues interValues;
 
@@ -103,7 +103,7 @@ int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int t
  *===========================================================================*/
 int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km, 
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma, 
-    int mdvar, double time, double location, double situation, double *A__db, long *warnings, IntermediateValues *interValues)
+    int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings, IntermediateValues *interValues)
 {
     *warnings = NO_WARNINGS;
 
@@ -111,11 +111,6 @@ int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const in
     int rtn = ValidateInputs(h_tx__meter, h_rx__meter, climate, time, location, situation, N_0, f__mhz, pol, epsilon, sigma, mdvar, warnings);
     if (rtn != SUCCESS)
         return rtn;
-
-    // switch from percentages to ratios
-    time /= 100;
-    location /= 100;
-    situation /= 100;
 
     // additional area mode parameter validation checks
     if (d__km <= 0)
@@ -222,7 +217,7 @@ int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const in
  *===========================================================================*/
 int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, double confidence, double reliability, double *A__db, long *warnings)
+    int mdvar, const double confidence, const double reliability, double *A__db, long *warnings)
 {
     IntermediateValues interValues;
 
@@ -285,7 +280,7 @@ int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx
  *===========================================================================*/
 int ITM_AREA_CR_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
     const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
-    int mdvar, double confidence, double reliability, double *A__db, long *warnings, IntermediateValues *interValues)
+    int mdvar, const double confidence, const double reliability, double *A__db, long *warnings, IntermediateValues *interValues)
 {
     int rtn = ITM_AREA_TLS_Ex(h_tx__meter, h_rx__meter, tx_site_criteria, rx_site_criteria, d__km,
         delta_h__meter, climate, N_0, f__mhz, pol, epsilon, sigma,

--- a/src/itm_area.cpp
+++ b/src/itm_area.cpp
@@ -47,7 +47,7 @@
  |
  *===========================================================================*/
 int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
-    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
+    const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     const int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -102,7 +102,7 @@ int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int t
  |
  *===========================================================================*/
 int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km, 
-    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma, 
+    const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma, 
     const int mdvar, const double time, const double location, const double situation, double *A__db, long *warnings, IntermediateValues *interValues)
 {
     *warnings = NO_WARNINGS;
@@ -216,7 +216,7 @@ int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const in
  |
  *===========================================================================*/
 int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
-    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
+    const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     const int mdvar, const double confidence, const double reliability, double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -279,7 +279,7 @@ int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx
  |
  *===========================================================================*/
 int ITM_AREA_CR_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
-    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
+    const double delta_h__meter, const int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     const int mdvar, const double confidence, const double reliability, double *A__db, long *warnings, IntermediateValues *interValues)
 {
     int rtn = ITM_AREA_TLS_Ex(h_tx__meter, h_rx__meter, tx_site_criteria, rx_site_criteria, d__km,

--- a/src/itm_area.cpp
+++ b/src/itm_area.cpp
@@ -46,8 +46,8 @@
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_AREA_TLS(double h_tx__meter, double h_rx__meter, int tx_site_criteria, int rx_site_criteria, double d__km,
-    double delta_h__meter, int climate, double N_0, double f__mhz, int pol, double epsilon, double sigma,
+int ITM_AREA_TLS(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
+    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, double time, double location, double situation, double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -101,8 +101,8 @@ int ITM_AREA_TLS(double h_tx__meter, double h_rx__meter, int tx_site_criteria, i
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_AREA_TLS_Ex(double h_tx__meter, double h_rx__meter, int tx_site_criteria, int rx_site_criteria, double d__km, 
-    double delta_h__meter, int climate, double N_0, double f__mhz, int pol, double epsilon, double sigma, 
+int ITM_AREA_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km, 
+    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma, 
     int mdvar, double time, double location, double situation, double *A__db, long *warnings, IntermediateValues *interValues)
 {
     *warnings = NO_WARNINGS;
@@ -220,8 +220,8 @@ int ITM_AREA_TLS_Ex(double h_tx__meter, double h_rx__meter, int tx_site_criteria
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_AREA_CR(double h_tx__meter, double h_rx__meter, int tx_site_criteria, int rx_site_criteria, double d__km,
-    double delta_h__meter, int climate, double N_0, double f__mhz, int pol, double epsilon, double sigma,
+int ITM_AREA_CR(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
+    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, double confidence, double reliability, double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -283,8 +283,8 @@ int ITM_AREA_CR(double h_tx__meter, double h_rx__meter, int tx_site_criteria, in
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_AREA_CR_Ex(double h_tx__meter, double h_rx__meter, int tx_site_criteria, int rx_site_criteria, double d__km,
-    double delta_h__meter, int climate, double N_0, double f__mhz, int pol, double epsilon, double sigma,
+int ITM_AREA_CR_Ex(const double h_tx__meter, const double h_rx__meter, const int tx_site_criteria, const int rx_site_criteria, const double d__km,
+    const double delta_h__meter, int climate, const double N_0, const double f__mhz, const int pol, const double epsilon, const double sigma,
     int mdvar, double confidence, double reliability, double *A__db, long *warnings, IntermediateValues *interValues)
 {
     int rtn = ITM_AREA_TLS_Ex(h_tx__meter, h_rx__meter, tx_site_criteria, rx_site_criteria, d__km,

--- a/src/itm_p2p.cpp
+++ b/src/itm_p2p.cpp
@@ -37,7 +37,7 @@
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
     const int pol, const double epsilon, const double sigma, const int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings)
 {
@@ -81,7 +81,7 @@ int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
     const int pol, const double epsilon, const double sigma, const int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings)
 {
@@ -134,7 +134,7 @@ int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double 
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
     const int pol, const double epsilon, const double sigma, const int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {
@@ -177,7 +177,7 @@ int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const doub
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], const int climate, const double N_0, const double f__mhz,
     const int pol, const double epsilon, const double sigma, const int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {

--- a/src/itm_p2p.cpp
+++ b/src/itm_p2p.cpp
@@ -37,7 +37,7 @@
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_TLS(double h_tx__meter, double h_rx__meter, double pfl[], int climate, double N_0, double f__mhz,
+int ITM_P2P_TLS(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
     int pol, double epsilon, double sigma, int mdvar, double time, double location, double situation,
     double *A__db, long *warnings)
 {
@@ -81,7 +81,7 @@ int ITM_P2P_TLS(double h_tx__meter, double h_rx__meter, double pfl[], int climat
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_CR(double h_tx__meter, double h_rx__meter, double pfl[], int climate, double N_0, double f__mhz,
+int ITM_P2P_CR(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
     int pol, double epsilon, double sigma, int mdvar, double confidence, double reliability,
     double *A__db, long *warnings)
 {
@@ -134,7 +134,7 @@ int ITM_P2P_CR(double h_tx__meter, double h_rx__meter, double pfl[], int climate
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_CR_Ex(double h_tx__meter, double h_rx__meter, double pfl[], int climate, double N_0, double f__mhz,
+int ITM_P2P_CR_Ex(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
     int pol, double epsilon, double sigma, int mdvar, double confidence, double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {
@@ -177,7 +177,7 @@ int ITM_P2P_CR_Ex(double h_tx__meter, double h_rx__meter, double pfl[], int clim
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_TLS_Ex(double h_tx__meter, double h_rx__meter, double pfl[], int climate, double N_0, double f__mhz,
+int ITM_P2P_TLS_Ex(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
     int pol, double epsilon, double sigma, int mdvar, double time, double location, double situation,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {
@@ -217,7 +217,7 @@ int ITM_P2P_TLS_Ex(double h_tx__meter, double h_rx__meter, double pfl[], int cli
 
     InitializePointToPoint(f__mhz, h_sys__meter, N_0, pol, epsilon, sigma, &Z_g, &gamma_e, &N_s);
 
-    double h__meter[2] = { h_tx__meter, h_rx__meter };
+    const double h__meter[2] = { h_tx__meter, h_rx__meter };
     QuickPfl(pfl, gamma_e, h__meter, theta_hzn, d_hzn__meter, h_e__meter, &delta_h__meter, &d__meter);
 
     // Reference attenuation, in dB

--- a/src/itm_p2p.cpp
+++ b/src/itm_p2p.cpp
@@ -199,7 +199,7 @@ int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const dou
 
     interValues->d__km = (pfl[0] * pfl[1]) / 1000;
 
-    int np = int(pfl[0]);       // number of points in the pfl
+    const int np = int(pfl[0]); // number of points in the pfl
 
     // compute the average path height, ignoring first and last 10%
     int p10 = int(0.1 * np);    // 10% of np

--- a/src/itm_p2p.cpp
+++ b/src/itm_p2p.cpp
@@ -38,7 +38,7 @@
  |
  *===========================================================================*/
 int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, double time, double location, double situation,
+    const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -82,7 +82,7 @@ int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double
  |
  *===========================================================================*/
 int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, double confidence, double reliability,
+    const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -135,7 +135,7 @@ int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double 
  |
  *===========================================================================*/
 int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, double confidence, double reliability,
+    const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {
     int rtn = ITM_P2P_TLS_Ex(h_tx__meter, h_rx__meter, pfl, climate, N_0, f__mhz, pol, epsilon, sigma, mdvar,
@@ -178,7 +178,7 @@ int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const doub
  |
  *===========================================================================*/
 int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, double time, double location, double situation,
+    const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {
     double N_s;                 // Surface refractivity, in N-Units
@@ -200,11 +200,6 @@ int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const dou
     interValues->d__km = (pfl[0] * pfl[1]) / 1000;
 
     int np = int(pfl[0]);       // number of points in the pfl
-
-    // switch from percentages to ratios
-    time /= 100;
-    location /= 100;
-    situation /= 100;
 
     // compute the average path height, ignoring first and last 10%
     int p10 = int(0.1 * np);    // 10% of np

--- a/src/itm_p2p.cpp
+++ b/src/itm_p2p.cpp
@@ -37,8 +37,8 @@
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_TLS(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
-    int pol, double epsilon, double sigma, int mdvar, double time, double location, double situation,
+int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+    const int pol, const double epsilon, const double sigma, int mdvar, double time, double location, double situation,
     double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -81,8 +81,8 @@ int ITM_P2P_TLS(double h_tx__meter, double h_rx__meter, const double pfl[], int 
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_CR(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
-    int pol, double epsilon, double sigma, int mdvar, double confidence, double reliability,
+int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+    const int pol, const double epsilon, const double sigma, int mdvar, double confidence, double reliability,
     double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -134,8 +134,8 @@ int ITM_P2P_CR(double h_tx__meter, double h_rx__meter, const double pfl[], int c
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_CR_Ex(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
-    int pol, double epsilon, double sigma, int mdvar, double confidence, double reliability,
+int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+    const int pol, const double epsilon, const double sigma, int mdvar, double confidence, double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {
     int rtn = ITM_P2P_TLS_Ex(h_tx__meter, h_rx__meter, pfl, climate, N_0, f__mhz, pol, epsilon, sigma, mdvar,
@@ -177,8 +177,8 @@ int ITM_P2P_CR_Ex(double h_tx__meter, double h_rx__meter, const double pfl[], in
  |      Returns:  error             - Error code
  |
  *===========================================================================*/
-int ITM_P2P_TLS_Ex(double h_tx__meter, double h_rx__meter, const double pfl[], int climate, double N_0, double f__mhz,
-    int pol, double epsilon, double sigma, int mdvar, double time, double location, double situation,
+int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
+    const int pol, const double epsilon, const double sigma, int mdvar, double time, double location, double situation,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {
     double N_s;                 // Surface refractivity, in N-Units

--- a/src/itm_p2p.cpp
+++ b/src/itm_p2p.cpp
@@ -38,7 +38,7 @@
  |
  *===========================================================================*/
 int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
+    const int pol, const double epsilon, const double sigma, const int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -82,7 +82,7 @@ int ITM_P2P_TLS(const double h_tx__meter, const double h_rx__meter, const double
  |
  *===========================================================================*/
 int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
+    const int pol, const double epsilon, const double sigma, const int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings)
 {
     IntermediateValues interValues;
@@ -135,7 +135,7 @@ int ITM_P2P_CR(const double h_tx__meter, const double h_rx__meter, const double 
  |
  *===========================================================================*/
 int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, const double confidence, const double reliability,
+    const int pol, const double epsilon, const double sigma, const int mdvar, const double confidence, const double reliability,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {
     int rtn = ITM_P2P_TLS_Ex(h_tx__meter, h_rx__meter, pfl, climate, N_0, f__mhz, pol, epsilon, sigma, mdvar,
@@ -178,7 +178,7 @@ int ITM_P2P_CR_Ex(const double h_tx__meter, const double h_rx__meter, const doub
  |
  *===========================================================================*/
 int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const double pfl[], int climate, const double N_0, const double f__mhz,
-    const int pol, const double epsilon, const double sigma, int mdvar, const double time, const double location, const double situation,
+    const int pol, const double epsilon, const double sigma, const int mdvar, const double time, const double location, const double situation,
     double *A__db, long *warnings, IntermediateValues *interValues)
 {
     double N_s;                 // Surface refractivity, in N-Units

--- a/src/itm_p2p.cpp
+++ b/src/itm_p2p.cpp
@@ -199,11 +199,11 @@ int ITM_P2P_TLS_Ex(const double h_tx__meter, const double h_rx__meter, const dou
 
     interValues->d__km = (pfl[0] * pfl[1]) / 1000;
 
-    const int np = int(pfl[0]); // number of points in the pfl
+    const int np = int(pfl[0]);     // number of points in the pfl
 
     // compute the average path height, ignoring first and last 10%
-    int p10 = int(0.1 * np);    // 10% of np
-    double h_sys__meter = 0;    // Height of the system above mean sea level
+    const int p10 = int(0.1 * np);  // 10% of np
+    double h_sys__meter = 0;        // Height of the system above mean sea level
 
     for (int i = p10; i <= np - p10; i++)
         h_sys__meter += pfl[i + 2];

--- a/win32/ITMDrvr/PointToPointMode.cpp
+++ b/win32/ITMDrvr/PointToPointMode.cpp
@@ -6,12 +6,12 @@
 
 // ITM DLL Functions
 typedef int(__stdcall *itm_p2p_tls_ex_func)(double h_tx__meter, double h_rx__meter,
-    double pfl[], int climate, double N_0, double f__mhz, int pol, double epsilon,
+    const double pfl[], int climate, double N_0, double f__mhz, int pol, double epsilon,
     double sigma, int mdvar, double time, double location, double situation,
     double *A__db, long *warnings, struct IntermediateValues *interValues);
 
 typedef int(__stdcall *itm_p2p_cr_ex_func)(double h_tx__meter, double h_rx__meter,
-    double pfl[], int climate, double N_0, double f__mhz, int pol, double epsilon,
+    const double pfl[], int climate, double N_0, double f__mhz, int pol, double epsilon,
     double sigma, int mdvar, double confidence, double reliability,
     double *A__db, long *warnings, struct IntermediateValues *interValues);
 


### PR DESCRIPTION
Prompted by #9, this pull request retrofits the ITM codebase with [`const` correctness](https://isocpp.org/wiki/faq/const-correctness) wherever applicable. I used a [static code analysis tool](https://github.com/danmar/cppcheck) to evaluate the ITM and ITMDrvr source code, and then modified the code to use `const` as much as possible. I tested the changes by compiling and using ITMDrvr to run the included example cases, to verify outputs have not changed.

Note for @wkozmaNTIA: I did not modify the C#/.NET wrapper to account for these changes, nor did I modify any version numbers. I'll leave these to you.