### PR TITLE
Add Rounding to Fix Numeric Error in LinearLeastSquaresFit

### DIFF
--- a/src/LinearLeastSquaresFit.cpp
+++ b/src/LinearLeastSquaresFit.cpp
@@ -18,13 +18,13 @@ void LinearLeastSquaresFit(const double pfl[], const double d_start, const doubl
 {
     const int np = (int)pfl[0];
 
-    int i_start = int(fdim(d_start / pfl[1], 0.0));
-    int i_end = np - int(fdim(np, d_end / pfl[1]));
+    int i_start = int(round(fdim(d_start / pfl[1], 0.0)));
+    int i_end = np - int(round(fdim(np, d_end / pfl[1])));
 
     if (i_end <= i_start)
     {
-        i_start = (int)fdim(i_start, 1.0);
-        i_end = np - (int)fdim(np, i_end + 1.0);
+        i_start = (int)round(fdim(i_start, 1.0));
+        i_end = np - (int)round(fdim(np, i_end + 1.0));
     }
 
     const double x_length = i_end - i_start;


### PR DESCRIPTION
Fixes #21 

This issue is fixed by adding rounding to fix the numeric error in LinearLeastSquaresFit.

Examples of numeric error and rounding correction in LinearLeastSquaresFit are below
(values observed debugging in // comments). The examples include "_r" variables
to observe the rounding fix.

Case 1:

Windows PFL:
d_start / pfl[1] // 1490.9999999999491
int(d_start / pfl[1]) // 1490
int i_start = int(fdim(d_start / pfl[1], 0.0)); // 1490
int i_start_r = int(round(fdim(d_start / pfl[1], 0.0))); // 1491
d_end / pfl[1] // 1498.9999999999945
int(np - (np - (d_end / pfl[1]))) // 1498
int i_end = np - int(fdim(np, d_end / pfl[1])); // 1499
int i_end_r = np - int(round(fdim(np, d_end / pfl[1]))); // 1499

Linux PFL:
d_start / pfl[1] // 1491.0000000000146
int(d_start / pfl[1]) // 1491
int i_start = int(fdim(d_start / pfl[1], 0.0)); // 1491
int i_start_r = int(round(fdim(d_start / pfl[1], 0.0))); // 1491
d_end / pfl[1] // 1499.0000000000018
int(np - (np - (d_end / pfl[1]))) // 1499
int i_end = np - int(fdim(np, d_end / pfl[1])); // 1500
int i_end_r = np - int(round(fdim(np, d_end / pfl[1]))); // 1499

Case 2:

Windows PFL:
d_start / pfl[1] // 1056.9999999999991
int(d_start / pfl[1]) // 1056
int i_start = int(fdim(d_start / pfl[1], 0.0)); // 1056
int i_start_r = int(round(fdim(d_start / pfl[1], 0.0))); // 1057
d_end / pfl[1] // 1064.9999999999998
int(np - (np - (d_end / pfl[1]))) // 1064
int i_end = np - int(fdim(np, d_end / pfl[1])); // 1065
int i_end_r = np - int(round(fdim(np, d_end / pfl[1]))); // 1065

Linux PFL:
d_start / pfl[1] // 1057.0000000000084
int(d_start / pfl[1]) // 1057
int i_start = int(fdim(d_start / pfl[1], 0.0)); // 1057
int i_start_r = int(round(fdim(d_start / pfl[1], 0.0))); // 1057
d_end / pfl[1] // 1065.0000000000009
int(np - (np - (d_end / pfl[1]))) // 1065
int i_end = np - int(fdim(np, d_end / pfl[1])); // 1066
int i_end_r = np - int(round(fdim(np, d_end / pfl[1]))); // 1065

Here are output files after applying the fix for the 2 cases in original issue, showing matching results:
[case_1_itm_command_output_linux_pfl.txt](https://github.com/user-attachments/files/17851823/case_1_itm_command_output_linux_pfl.txt)
[case_1_itm_command_output_windows_pfl.txt](https://github.com/user-attachments/files/17851824/case_1_itm_command_output_windows_pfl.txt)
[case_2_itm_command_output_linux_pfl.txt](https://github.com/user-attachments/files/17851825/case_2_itm_command_output_linux_pfl.txt)
[case_2_itm_command_output_windows_pfl.txt](https://github.com/user-attachments/files/17851826/case_2_itm_command_output_windows_pfl.txt)
